### PR TITLE
feat: establish Toontown toolkit foundation with quick-start and smoke validation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repository.
+* @sirwranwrap

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+- What changed:
+- Why this change is needed:
+
+## Scope Check
+- [ ] This PR handles one logical objective.
+- [ ] I did not mix broad refactors with feature behavior changes.
+- [ ] File names and symbols reflect domain intent.
+
+## Validation
+- [ ] I ran `scripts/primary-checks.ps1`.
+- [ ] I reviewed `scripts/manual-readiness.ps1` output for branch and diff sanity.
+- [ ] I tested the affected Unity tool window flow manually.
+
+## Docs and Communication
+- [ ] I updated `docs/TOONTOWN_MIGRATION_PLAN.md` if behavior changed.
+- [ ] I captured any beginner-facing reminders in `docs/BEGINNER_REMINDERS.md`.
+- [ ] Commit messages explain user-visible impact in plain language.
+
+## Beginner Reminder
+Common mistakes:
+- mixing unrelated edits into one commit
+- skipping quick checks before commit
+- editing POTCO logic when only Toontown scaffolding was intended

--- a/.github/workflows/commit-quality.yml
+++ b/.github/workflows/commit-quality.yml
@@ -1,0 +1,43 @@
+name: Commit Quality
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches:
+      - "codex/**"
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref for commit check (example: origin/main)"
+        required: false
+        default: "origin/main"
+
+jobs:
+  commit_quality:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch default base
+        shell: pwsh
+        run: git fetch origin main --depth=1
+
+      - name: Commit check for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: pwsh
+        run: ./scripts/commit-message-check.ps1 -BaseRef "origin/${{ github.base_ref }}"
+
+      - name: Commit check for push
+        if: ${{ github.event_name == 'push' }}
+        shell: pwsh
+        run: ./scripts/commit-message-check.ps1 -BaseRef "origin/main"
+
+      - name: Commit check for manual dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: pwsh
+        run: ./scripts/commit-message-check.ps1 -BaseRef "${{ github.event.inputs.base_ref }}"

--- a/.github/workflows/manual-readiness.yml
+++ b/.github/workflows/manual-readiness.yml
@@ -1,0 +1,23 @@
+name: Manual Readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref for diff summary (example: upstream/main or origin/main)"
+        required: false
+        default: "origin/main"
+
+jobs:
+  readiness:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run manual readiness bundle
+        shell: pwsh
+        run: ./scripts/manual-readiness.ps1 -BaseRef "${{ github.event.inputs.base_ref }}"

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -1,0 +1,36 @@
+name: PR Readiness
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref for readiness summary (example: origin/main)"
+        required: false
+        default: "origin/main"
+
+jobs:
+  readiness:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR base branch
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: pwsh
+        run: git fetch origin "${{ github.base_ref }}" --depth=1
+
+      - name: Run readiness for PR base
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: pwsh
+        run: ./scripts/manual-readiness.ps1 -BaseRef "origin/${{ github.base_ref }}"
+
+      - name: Run readiness for manual base
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: pwsh
+        run: ./scripts/manual-readiness.ps1 -BaseRef "${{ github.event.inputs.base_ref }}"

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,4 +1,4 @@
-name: Quality Checks
+name: Primary CI
 
 on:
   pull_request:
@@ -7,15 +7,16 @@ on:
     branches:
       - main
       - "codex/**"
+  workflow_dispatch:
 
 jobs:
-  checks:
+  primary_checks:
     runs-on: windows-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run project checks
+      - name: Run primary checks
         shell: pwsh
-        run: ./scripts/checks.ps1
+        run: ./scripts/primary-checks.ps1

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,0 +1,21 @@
+name: Quality Checks
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches:
+      - main
+      - "codex/**"
+
+jobs:
+  checks:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run project checks
+        shell: pwsh
+        run: ./scripts/checks.ps1

--- a/.github/workflows/sun-action.yml
+++ b/.github/workflows/sun-action.yml
@@ -1,0 +1,18 @@
+name: Sun Action
+
+on:
+  schedule:
+    - cron: "0 17 * * 0"
+  workflow_dispatch:
+
+jobs:
+  sun_action:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run primary checks
+        shell: pwsh
+        run: ./scripts/primary-checks.ps1

--- a/.github/workflows/toontown-smoke-gate.yml
+++ b/.github/workflows/toontown-smoke-gate.yml
@@ -1,0 +1,28 @@
+name: Toontown Smoke Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "Assets/Editor/Toontown/**"
+      - "Assets/Editor/Toolkit/WorldData/Adapters/Toontown/**"
+      - "docs/TOONTOWN_QUICKSTART.md"
+      - "scripts/toontown-sample-sanity.ps1"
+      - "scripts/primary-checks.ps1"
+  workflow_dispatch:
+
+jobs:
+  smoke_gate:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run primary checks
+        shell: pwsh
+        run: ./scripts/primary-checks.ps1
+
+      - name: Run Toontown sample sanity
+        shell: pwsh
+        run: ./scripts/toontown-sample-sanity.ps1

--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -1,0 +1,18 @@
+name: Weekly Health
+
+on:
+  schedule:
+    - cron: "0 16 * * 1"
+  workflow_dispatch:
+
+jobs:
+  health:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run primary checks
+        shell: pwsh
+        run: ./scripts/primary-checks.ps1

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,15 +2,29 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Project: Run Checks",
+      "label": "Project: Run Primary Checks (Recommended)",
       "type": "shell",
       "command": "pwsh",
       "args": [
         "-NoProfile",
         "-ExecutionPolicy", "Bypass",
-        "-File", "scripts/checks.ps1"
+        "-File", "scripts/primary-checks.ps1"
       ],
-      "group": "test",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Project: Run Manual Readiness",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "scripts/manual-readiness.ps1"
+      ],
       "problemMatcher": []
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,18 @@
       "problemMatcher": []
     },
     {
+      "label": "Project: Run Commit Message Check",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "scripts/commit-message-check.ps1",
+        "-BaseRef", "upstream/main"
+      ],
+      "problemMatcher": []
+    },
+    {
       "label": "Git: Status",
       "type": "shell",
       "command": "git status --short",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,6 +40,17 @@
       "problemMatcher": []
     },
     {
+      "label": "Project: Run Toontown Sample Sanity",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "scripts/toontown-sample-sanity.ps1"
+      ],
+      "problemMatcher": []
+    },
+    {
       "label": "Git: Status",
       "type": "shell",
       "command": "git status --short",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Project: Run Checks",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "scripts/checks.ps1"
+      ],
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "Git: Status",
+      "type": "shell",
+      "command": "git status --short",
+      "problemMatcher": []
+    },
+    {
+      "label": "Git: Recent Commits",
+      "type": "shell",
+      "command": "git log --oneline --decorate -n 10",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Collaboration Guide
+
+This file defines how human contributors and coding agents should work in this repository.
+
+## Core Rules
+- Keep changes scoped to one objective per commit.
+- Prefer additive scaffolding before risky refactors.
+- Do not rewrite POTCO behavior when adding Toontown support unless explicitly planned.
+- Document intent for non-trivial changes in `docs/TOONTOWN_MIGRATION_PLAN.md`.
+
+## Branching and Commits
+- Use feature branches prefixed with `codex/`.
+- Write commit messages in imperative style.
+- Keep commits reviewable (small and focused).
+
+## Safety Checks Before Commit
+- No unresolved merge conflict markers.
+- No unrelated files included in the commit.
+- No placeholder TODOs without context.
+
+## Task Order for Migration
+1. Shared interfaces and routing
+2. POTCO adapters behind interfaces
+3. Toontown adapters behind interfaces
+4. Validation and cleanup
+
+## Notes for Agents
+- Respect existing style and directory boundaries.
+- Do not fabricate authorship or hide generated work.
+- Surface assumptions early when requirements are unclear.

--- a/Assets/Editor/Toolkit/ToolkitSettingsWindow.cs
+++ b/Assets/Editor/Toolkit/ToolkitSettingsWindow.cs
@@ -1,0 +1,80 @@
+using Toolkit.Core;
+using UnityEditor;
+using UnityEngine;
+
+namespace Toolkit.Editor
+{
+    public sealed class ToolkitSettingsWindow : EditorWindow
+    {
+        private const string SettingsDirectory = "Assets/Resources/Toolkit";
+        private const string SettingsAssetPath = SettingsDirectory + "/ToolkitProjectSettings.asset";
+
+        private ToolkitProjectSettings settings;
+
+        [MenuItem("Toolkit/Settings")]
+        public static void ShowWindow()
+        {
+            GetWindow<ToolkitSettingsWindow>("Toolkit Settings");
+        }
+
+        private void OnEnable()
+        {
+            settings = LoadOrCreateSettings();
+        }
+
+        private void OnGUI()
+        {
+            if (settings == null)
+            {
+                EditorGUILayout.HelpBox("Failed to load ToolkitProjectSettings asset.", MessageType.Error);
+                if (GUILayout.Button("Retry"))
+                {
+                    settings = LoadOrCreateSettings();
+                }
+
+                return;
+            }
+
+            EditorGUILayout.LabelField("Toolkit Project Settings", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+
+            EditorGUI.BeginChangeCheck();
+            settings.activeGameFlavor = (GameFlavor)EditorGUILayout.EnumPopup("Active Game", settings.activeGameFlavor);
+            settings.enableVerboseLogs = EditorGUILayout.Toggle("Enable Verbose Logs", settings.enableVerboseLogs);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorUtility.SetDirty(settings);
+                AssetDatabase.SaveAssets();
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox("Use this setting as the top-level switch for game-specific adapters.", MessageType.Info);
+        }
+
+        private static ToolkitProjectSettings LoadOrCreateSettings()
+        {
+            var asset = AssetDatabase.LoadAssetAtPath<ToolkitProjectSettings>(SettingsAssetPath);
+            if (asset != null)
+            {
+                return asset;
+            }
+
+            if (!AssetDatabase.IsValidFolder("Assets/Resources"))
+            {
+                AssetDatabase.CreateFolder("Assets", "Resources");
+            }
+
+            if (!AssetDatabase.IsValidFolder(SettingsDirectory))
+            {
+                AssetDatabase.CreateFolder("Assets/Resources", "Toolkit");
+            }
+
+            asset = CreateInstance<ToolkitProjectSettings>();
+            AssetDatabase.CreateAsset(asset, SettingsAssetPath);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            return asset;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Potco/PotcoWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Potco/PotcoWorldDataDocumentReader.cs
@@ -1,0 +1,21 @@
+using System;
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData.Adapters.Potco
+{
+    public sealed class PotcoWorldDataDocumentReader : IWorldDataDocumentReader
+    {
+        public string FormatId => "potco.py.objectstruct";
+
+        public bool CanRead(string sourcePath)
+        {
+            return !string.IsNullOrWhiteSpace(sourcePath) && sourcePath.EndsWith(".py", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public WorldDataDocument ReadFromFile(string sourcePath)
+        {
+            throw new NotSupportedException(
+                "Shared POTCO document reader not wired yet. Use POTCO/World Data/Importer for behavior.");
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Potco/PotcoWorldDataDocumentWriter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Potco/PotcoWorldDataDocumentWriter.cs
@@ -1,0 +1,21 @@
+using System;
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData.Adapters.Potco
+{
+    public sealed class PotcoWorldDataDocumentWriter : IWorldDataDocumentWriter
+    {
+        public string FormatId => "potco.py.objectstruct";
+
+        public bool CanWrite(string outputPath)
+        {
+            return !string.IsNullOrWhiteSpace(outputPath) && outputPath.EndsWith(".py", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void WriteToFile(WorldDataDocument document, string outputPath)
+        {
+            throw new NotSupportedException(
+                "Shared POTCO document writer not wired yet. Use POTCO/World Data/Exporter for behavior.");
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Potco/PotcoWorldDataFormatAdapter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Potco/PotcoWorldDataFormatAdapter.cs
@@ -1,0 +1,14 @@
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData.Adapters.Potco
+{
+    public sealed class PotcoWorldDataFormatAdapter : IWorldDataFormatAdapter
+    {
+        private static readonly IWorldDataDocumentReader ReaderInstance = new PotcoWorldDataDocumentReader();
+        private static readonly IWorldDataDocumentWriter WriterInstance = new PotcoWorldDataDocumentWriter();
+
+        public string FormatId => "potco.py.objectstruct";
+        public IWorldDataDocumentReader Reader => ReaderInstance;
+        public IWorldDataDocumentWriter Writer => WriterInstance;
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownObjectTypeMapper.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownObjectTypeMapper.cs
@@ -10,6 +10,9 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
         private const string RelativeConfigPath = "Assets/Editor/Toontown/Config/ObjectTypeMap.json";
         private readonly ObjectTypeMapConfig config;
 
+        public static string ConfigRelativePath => RelativeConfigPath;
+        public static string ConfigFullPath => GetFullConfigPath();
+
         private ToontownObjectTypeMapper(ObjectTypeMapConfig config)
         {
             this.config = config ?? CreateDefaultConfig();

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownObjectTypeMapper.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownObjectTypeMapper.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace Toolkit.Editor.WorldData.Adapters.Toontown
+{
+    public sealed class ToontownObjectTypeMapper
+    {
+        private const string RelativeConfigPath = "Assets/Editor/Toontown/Config/ObjectTypeMap.json";
+        private readonly ObjectTypeMapConfig config;
+
+        private ToontownObjectTypeMapper(ObjectTypeMapConfig config)
+        {
+            this.config = config ?? CreateDefaultConfig();
+        }
+
+        public static ToontownObjectTypeMapper LoadOrCreateDefault(out string loadWarning)
+        {
+            loadWarning = null;
+            string fullPath = GetFullConfigPath();
+
+            if (!File.Exists(fullPath))
+            {
+                EnsureConfigDirectoryExists(fullPath);
+                var defaultConfig = CreateDefaultConfig();
+                File.WriteAllText(fullPath, JsonUtility.ToJson(defaultConfig, true));
+                loadWarning = $"Type map config not found. Created default config at {RelativeConfigPath}.";
+                return new ToontownObjectTypeMapper(defaultConfig);
+            }
+
+            try
+            {
+                string json = File.ReadAllText(fullPath);
+                var parsed = JsonUtility.FromJson<ObjectTypeMapConfig>(json);
+                if (parsed == null)
+                {
+                    loadWarning = $"Type map config could not be parsed. Falling back to defaults ({RelativeConfigPath}).";
+                    return new ToontownObjectTypeMapper(CreateDefaultConfig());
+                }
+
+                if (parsed.rules == null)
+                {
+                    parsed.rules = new List<ObjectTypeRule>();
+                }
+
+                if (string.IsNullOrWhiteSpace(parsed.defaultType))
+                {
+                    parsed.defaultType = "Unknown";
+                }
+
+                return new ToontownObjectTypeMapper(parsed);
+            }
+            catch (Exception ex)
+            {
+                loadWarning = $"Type map load failed: {ex.Message}. Falling back to defaults.";
+                return new ToontownObjectTypeMapper(CreateDefaultConfig());
+            }
+        }
+
+        public string InferTypeFromModel(string modelPath, out bool usedDefault)
+        {
+            usedDefault = true;
+
+            if (string.IsNullOrWhiteSpace(modelPath))
+            {
+                return config.defaultType;
+            }
+
+            for (int i = 0; i < config.rules.Count; i++)
+            {
+                var rule = config.rules[i];
+                if (rule == null || string.IsNullOrWhiteSpace(rule.modelContains) || string.IsNullOrWhiteSpace(rule.type))
+                {
+                    continue;
+                }
+
+                if (modelPath.IndexOf(rule.modelContains, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    usedDefault = false;
+                    return rule.type.Trim();
+                }
+            }
+
+            return config.defaultType;
+        }
+
+        private static string GetFullConfigPath()
+        {
+            return Path.Combine(Directory.GetCurrentDirectory(), RelativeConfigPath.Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        private static void EnsureConfigDirectoryExists(string fullPath)
+        {
+            string directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+        }
+
+        private static ObjectTypeMapConfig CreateDefaultConfig()
+        {
+            return new ObjectTypeMapConfig
+            {
+                defaultType = "Unknown",
+                rules = new List<ObjectTypeRule>
+                {
+                    new ObjectTypeRule { modelContains = "models/props/", type = "Prop" },
+                    new ObjectTypeRule { modelContains = "models/buildings/", type = "Building" },
+                    new ObjectTypeRule { modelContains = "models/char/", type = "Character" },
+                    new ObjectTypeRule { modelContains = "models/streets/", type = "Street" },
+                    new ObjectTypeRule { modelContains = "models/neighborhoods/", type = "Neighborhood" }
+                }
+            };
+        }
+
+        [Serializable]
+        private sealed class ObjectTypeMapConfig
+        {
+            public string defaultType = "Unknown";
+            public List<ObjectTypeRule> rules = new List<ObjectTypeRule>();
+        }
+
+        [Serializable]
+        private sealed class ObjectTypeRule
+        {
+            public string modelContains;
+            public string type;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownPropertyNormalizer.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownPropertyNormalizer.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Toolkit.Editor.WorldData.Adapters.Toontown
+{
+    public static class ToontownPropertyNormalizer
+    {
+        private static readonly Regex NumericRegex = new Regex(
+            @"^[-+]?(?:\d+\.?\d*|\.\d+)$",
+            RegexOptions.Compiled);
+
+        public static string NormalizeForDocument(string raw)
+        {
+            if (raw == null)
+            {
+                return string.Empty;
+            }
+
+            string trimmed = raw.Trim();
+            if (trimmed.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            // Keep tuple/list expressions as-is.
+            if (trimmed.StartsWith("(") || trimmed.StartsWith("["))
+            {
+                return trimmed;
+            }
+
+            if (trimmed == "True" || trimmed == "False" || trimmed == "None")
+            {
+                return trimmed;
+            }
+
+            if (NumericRegex.IsMatch(trimmed))
+            {
+                return double.Parse(trimmed, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+            }
+
+            return trimmed;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownPropertyOrdering.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownPropertyOrdering.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Toolkit.Editor.WorldData.Adapters.Toontown
+{
+    public static class ToontownPropertyOrdering
+    {
+        private static readonly string[] PreferredOrder =
+        {
+            "Type",
+            "Name",
+            "Model",
+            "Pos",
+            "GridPos",
+            "Hpr",
+            "Scale",
+            "DNA",
+            "Zone",
+            "Parent"
+        };
+
+        public static List<KeyValuePair<string, string>> Sort(IDictionary<string, string> properties)
+        {
+            var list = properties.ToList();
+            list.Sort(CompareProperties);
+            return list;
+        }
+
+        private static int CompareProperties(KeyValuePair<string, string> a, KeyValuePair<string, string> b)
+        {
+            int ai = IndexOfPreferred(a.Key);
+            int bi = IndexOfPreferred(b.Key);
+
+            if (ai != bi)
+            {
+                return ai.CompareTo(bi);
+            }
+
+            return string.Compare(a.Key, b.Key, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int IndexOfPreferred(string key)
+        {
+            for (int i = 0; i < PreferredOrder.Length; i++)
+            {
+                if (string.Equals(PreferredOrder[i], key, StringComparison.OrdinalIgnoreCase))
+                {
+                    return i;
+                }
+            }
+
+            return int.MaxValue;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -9,6 +9,7 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
 {
     public sealed class ToontownWorldDataDocumentReader : IWorldDataDocumentReader
     {
+        private const int MaxInferenceWarnings = 20;
         private static readonly Regex DictEntryRegex = new Regex(
             @"^\s*'([^']+)':\s*\{",
             RegexOptions.Compiled);
@@ -62,6 +63,13 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
             {
                 Name = Path.GetFileNameWithoutExtension(sourcePath)
             };
+            int warningCountFromInference = 0;
+            int suppressedInferenceWarnings = 0;
+            var typeMapper = ToontownObjectTypeMapper.LoadOrCreateDefault(out string mapperLoadWarning);
+            if (!string.IsNullOrWhiteSpace(mapperLoadWarning))
+            {
+                document.Warnings.Add(mapperLoadWarning);
+            }
 
             string[] lines = File.ReadAllLines(sourcePath);
             var stack = new Stack<ParseNode>();
@@ -133,6 +141,8 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                     Properties = new Dictionary<string, string>(node.Properties, StringComparer.OrdinalIgnoreCase)
                 };
 
+                ApplyTypeInference(worldObject, typeMapper, document, ref warningCountFromInference, ref suppressedInferenceWarnings);
+
                 document.Objects.Add(worldObject);
             }
 
@@ -148,6 +158,12 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                 {
                     document.Warnings.Add($"Duplicate object id detected: {group.Key} ({group.Count()} entries).");
                 }
+            }
+
+            if (suppressedInferenceWarnings > 0)
+            {
+                document.Warnings.Add(
+                    $"Suppressed {suppressedInferenceWarnings} additional type-inference warnings (limit {MaxInferenceWarnings}).");
             }
 
             return document;
@@ -195,6 +211,76 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
             }
 
             return false;
+        }
+
+        private static void ApplyTypeInference(
+            WorldDataObject worldObject,
+            ToontownObjectTypeMapper typeMapper,
+            WorldDataDocument document,
+            ref int warningCountFromInference,
+            ref int suppressedInferenceWarnings)
+        {
+            if (worldObject.Properties.ContainsKey("Type"))
+            {
+                return;
+            }
+
+            if (!worldObject.Properties.TryGetValue("Model", out string modelRaw))
+            {
+                AddInferenceWarning(
+                    document,
+                    $"Object '{worldObject.Id}' has no 'Type' or 'Model' property; type inference skipped.",
+                    ref warningCountFromInference,
+                    ref suppressedInferenceWarnings);
+                return;
+            }
+
+            string modelPath = NormalizeModelValue(modelRaw);
+            string inferredType = typeMapper.InferTypeFromModel(modelPath, out bool usedDefault);
+            worldObject.Properties["Type"] = inferredType;
+
+            if (usedDefault)
+            {
+                AddInferenceWarning(
+                    document,
+                    $"Object '{worldObject.Id}' model '{modelPath}' did not match mapping rules; default type '{inferredType}' applied.",
+                    ref warningCountFromInference,
+                    ref suppressedInferenceWarnings);
+            }
+        }
+
+        private static string NormalizeModelValue(string modelRaw)
+        {
+            if (string.IsNullOrWhiteSpace(modelRaw))
+            {
+                return string.Empty;
+            }
+
+            string trimmed = modelRaw.Trim();
+            if ((trimmed.StartsWith("'") && trimmed.EndsWith("'")) ||
+                (trimmed.StartsWith("\"") && trimmed.EndsWith("\"")))
+            {
+                return trimmed.Substring(1, trimmed.Length - 2);
+            }
+
+            return trimmed;
+        }
+
+        private static void AddInferenceWarning(
+            WorldDataDocument document,
+            string message,
+            ref int warningCountFromInference,
+            ref int suppressedInferenceWarnings)
+        {
+            if (warningCountFromInference < MaxInferenceWarnings)
+            {
+                document.Warnings.Add(message);
+                warningCountFromInference++;
+            }
+            else
+            {
+                suppressedInferenceWarnings++;
+            }
         }
 
         private sealed class ParseNode

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -119,6 +119,11 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
             }
 
             var likelyObjects = parsedNodes.Where(IsLikelyWorldObject).ToList();
+            var duplicateIdCounts = likelyObjects
+                .GroupBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .ToList();
+
             foreach (var node in likelyObjects)
             {
                 var worldObject = new WorldDataObject
@@ -129,6 +134,20 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                 };
 
                 document.Objects.Add(worldObject);
+            }
+
+            if (document.Objects.Count == 0)
+            {
+                document.Warnings.Add(
+                    "No likely world objects were detected. Verify source format assumptions for this file.");
+            }
+
+            if (duplicateIdCounts.Count > 0)
+            {
+                foreach (var group in duplicateIdCounts)
+                {
+                    document.Warnings.Add($"Duplicate object id detected: {group.Key} ({group.Count()} entries).");
+                }
             }
 
             return document;

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -1,10 +1,44 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Toolkit.Editor.WorldData.Contracts;
 
 namespace Toolkit.Editor.WorldData.Adapters.Toontown
 {
     public sealed class ToontownWorldDataDocumentReader : IWorldDataDocumentReader
     {
+        private static readonly Regex DictEntryRegex = new Regex(
+            @"^\s*'([^']+)':\s*\{",
+            RegexOptions.Compiled);
+
+        private static readonly Regex PropertyRegex = new Regex(
+            @"^\s*'([^']+)':\s*(.+?)\s*,?\s*$",
+            RegexOptions.Compiled);
+
+        private static readonly HashSet<string> ReservedDictKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Objects",
+            "Visual",
+            "Properties",
+            "Attribs"
+        };
+
+        private static readonly HashSet<string> LikelyObjectProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Pos",
+            "GridPos",
+            "Hpr",
+            "Scale",
+            "Type",
+            "Model",
+            "Name",
+            "Zone",
+            "Parent",
+            "DNA"
+        };
+
         public string FormatId => "toontown.py.zone";
 
         public bool CanRead(string sourcePath)
@@ -14,8 +48,142 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
 
         public WorldDataDocument ReadFromFile(string sourcePath)
         {
-            throw new NotSupportedException(
-                "Toontown document reader is a scaffold and has not been implemented yet.");
+            if (!CanRead(sourcePath))
+            {
+                throw new NotSupportedException($"Unsupported file type for Toontown reader: {sourcePath}");
+            }
+
+            if (!File.Exists(sourcePath))
+            {
+                throw new FileNotFoundException("Toontown source file not found.", sourcePath);
+            }
+
+            var document = new WorldDataDocument
+            {
+                Name = Path.GetFileNameWithoutExtension(sourcePath)
+            };
+
+            string[] lines = File.ReadAllLines(sourcePath);
+            var stack = new Stack<ParseNode>();
+            var parsedNodes = new List<ParseNode>();
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                int indent = GetIndent(line);
+
+                while (stack.Count > 0 && indent <= stack.Peek().Indent)
+                {
+                    stack.Pop();
+                }
+
+                Match entryMatch = DictEntryRegex.Match(line);
+                if (entryMatch.Success)
+                {
+                    string key = entryMatch.Groups[1].Value.Trim();
+                    if (IsCandidateObjectKey(key))
+                    {
+                        var node = new ParseNode
+                        {
+                            Id = key,
+                            ParentId = stack.Count > 0 ? stack.Peek().Id : null,
+                            Indent = indent
+                        };
+
+                        parsedNodes.Add(node);
+                        stack.Push(node);
+                    }
+
+                    continue;
+                }
+
+                if (stack.Count == 0)
+                {
+                    continue;
+                }
+
+                Match propertyMatch = PropertyRegex.Match(line);
+                if (!propertyMatch.Success)
+                {
+                    continue;
+                }
+
+                string propKey = propertyMatch.Groups[1].Value.Trim();
+                string propValue = propertyMatch.Groups[2].Value.Trim();
+                stack.Peek().Properties[propKey] = propValue;
+            }
+
+            var likelyObjects = parsedNodes.Where(IsLikelyWorldObject).ToList();
+            foreach (var node in likelyObjects)
+            {
+                var worldObject = new WorldDataObject
+                {
+                    Id = node.Id,
+                    ParentId = likelyObjects.Any(x => x.Id == node.ParentId) ? node.ParentId : null,
+                    Properties = new Dictionary<string, string>(node.Properties, StringComparer.OrdinalIgnoreCase)
+                };
+
+                document.Objects.Add(worldObject);
+            }
+
+            return document;
+        }
+
+        private static int GetIndent(string line)
+        {
+            int indent = 0;
+            while (indent < line.Length && char.IsWhiteSpace(line[indent]))
+            {
+                indent++;
+            }
+
+            return indent;
+        }
+
+        private static bool IsCandidateObjectKey(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            if (ReservedDictKeys.Contains(key))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool IsLikelyWorldObject(ParseNode node)
+        {
+            if (node.Properties.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (string key in node.Properties.Keys)
+            {
+                if (LikelyObjectProperties.Contains(key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private sealed class ParseNode
+        {
+            public string Id;
+            public string ParentId;
+            public int Indent;
+            public Dictionary<string, string> Properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -77,6 +77,10 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
             int objectsScopeDepth = 0;
             bool sawObjectsScope = false;
             var parsedNodes = new List<ParseNode>();
+            ParseNode pendingPropertyNode = null;
+            string pendingPropertyKey = null;
+            string pendingPropertyRawValue = null;
+            int pendingContinuationBalance = 0;
 
             for (int i = 0; i < lines.Length; i++)
             {
@@ -100,6 +104,25 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                     {
                         objectsScopeDepth--;
                     }
+                }
+
+                if (pendingPropertyNode != null)
+                {
+                    string continuationSegment = line.Trim();
+                    pendingPropertyRawValue = $"{pendingPropertyRawValue} {continuationSegment}";
+                    pendingContinuationBalance += GetContinuationBalanceDelta(continuationSegment);
+
+                    if (pendingContinuationBalance <= 0)
+                    {
+                        string completedValue = ToontownPropertyNormalizer.NormalizeForDocument(pendingPropertyRawValue);
+                        pendingPropertyNode.Properties[pendingPropertyKey] = completedValue;
+                        pendingPropertyNode = null;
+                        pendingPropertyKey = null;
+                        pendingPropertyRawValue = null;
+                        pendingContinuationBalance = 0;
+                    }
+
+                    continue;
                 }
 
                 Match entryMatch = DictEntryRegex.Match(line);
@@ -149,8 +172,27 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                 }
 
                 string propKey = propertyMatch.Groups[1].Value.Trim();
-                string propValue = ToontownPropertyNormalizer.NormalizeForDocument(propertyMatch.Groups[2].Value);
+                string propRawValue = propertyMatch.Groups[2].Value;
+
+                if (ShouldStartContinuation(propRawValue, out int continuationBalance))
+                {
+                    pendingPropertyNode = stack.Peek();
+                    pendingPropertyKey = propKey;
+                    pendingPropertyRawValue = propRawValue;
+                    pendingContinuationBalance = continuationBalance;
+                    continue;
+                }
+
+                string propValue = ToontownPropertyNormalizer.NormalizeForDocument(propRawValue);
                 stack.Peek().Properties[propKey] = propValue;
+            }
+
+            if (pendingPropertyNode != null)
+            {
+                string bestEffortValue = ToontownPropertyNormalizer.NormalizeForDocument(pendingPropertyRawValue);
+                pendingPropertyNode.Properties[pendingPropertyKey] = bestEffortValue;
+                document.Warnings.Add(
+                    $"Property '{pendingPropertyKey}' on object '{pendingPropertyNode.Id}' ended with unbalanced continuation; captured best-effort value.");
             }
 
             if (!sawObjectsScope)
@@ -314,6 +356,87 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
             {
                 suppressedInferenceWarnings++;
             }
+        }
+
+        private static bool ShouldStartContinuation(string rawValue, out int continuationBalance)
+        {
+            continuationBalance = 0;
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                return false;
+            }
+
+            string trimmed = rawValue.TrimStart();
+            if (trimmed.StartsWith("{"))
+            {
+                return false;
+            }
+
+            continuationBalance = GetContinuationBalanceDelta(trimmed);
+            if (continuationBalance <= 0)
+            {
+                return false;
+            }
+
+            if (trimmed.StartsWith("[") || trimmed.StartsWith("("))
+            {
+                return true;
+            }
+
+            return trimmed.IndexOf('(') >= 0;
+        }
+
+        private static int GetContinuationBalanceDelta(string text)
+        {
+            bool inSingleQuote = false;
+            bool inDoubleQuote = false;
+            bool escaped = false;
+            int delta = 0;
+
+            foreach (char c in text)
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (!inDoubleQuote && c == '\'')
+                {
+                    inSingleQuote = !inSingleQuote;
+                    continue;
+                }
+
+                if (!inSingleQuote && c == '"')
+                {
+                    inDoubleQuote = !inDoubleQuote;
+                    continue;
+                }
+
+                if (inSingleQuote || inDoubleQuote)
+                {
+                    continue;
+                }
+
+                if (c == '[' || c == '(')
+                {
+                    delta++;
+                    continue;
+                }
+
+                if (c == ']' || c == ')')
+                {
+                    delta--;
+                }
+            }
+
+            return delta;
         }
 
         private sealed class ParseNode

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -1,0 +1,21 @@
+using System;
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData.Adapters.Toontown
+{
+    public sealed class ToontownWorldDataDocumentReader : IWorldDataDocumentReader
+    {
+        public string FormatId => "toontown.py.zone";
+
+        public bool CanRead(string sourcePath)
+        {
+            return !string.IsNullOrWhiteSpace(sourcePath) && sourcePath.EndsWith(".py", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public WorldDataDocument ReadFromFile(string sourcePath)
+        {
+            throw new NotSupportedException(
+                "Toontown document reader is a scaffold and has not been implemented yet.");
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -73,6 +73,9 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
 
             string[] lines = File.ReadAllLines(sourcePath);
             var stack = new Stack<ParseNode>();
+            var dictScopeStack = new Stack<DictScope>();
+            int objectsScopeDepth = 0;
+            bool sawObjectsScope = false;
             var parsedNodes = new List<ParseNode>();
 
             for (int i = 0; i < lines.Length; i++)
@@ -90,11 +93,23 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                     stack.Pop();
                 }
 
+                while (dictScopeStack.Count > 0 && indent <= dictScopeStack.Peek().Indent)
+                {
+                    var popped = dictScopeStack.Pop();
+                    if (popped.IsObjectsScope)
+                    {
+                        objectsScopeDepth--;
+                    }
+                }
+
                 Match entryMatch = DictEntryRegex.Match(line);
                 if (entryMatch.Success)
                 {
                     string key = entryMatch.Groups[1].Value.Trim();
-                    if (IsCandidateObjectKey(key))
+                    bool isObjectsScope = string.Equals(key, "Objects", StringComparison.OrdinalIgnoreCase);
+                    bool insideObjectsScope = objectsScopeDepth > 0;
+
+                    if (insideObjectsScope && IsCandidateObjectKey(key))
                     {
                         var node = new ParseNode
                         {
@@ -105,6 +120,18 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
 
                         parsedNodes.Add(node);
                         stack.Push(node);
+                    }
+
+                    dictScopeStack.Push(new DictScope
+                    {
+                        Indent = indent,
+                        IsObjectsScope = isObjectsScope
+                    });
+
+                    if (isObjectsScope)
+                    {
+                        objectsScopeDepth++;
+                        sawObjectsScope = true;
                     }
 
                     continue;
@@ -124,6 +151,12 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                 string propKey = propertyMatch.Groups[1].Value.Trim();
                 string propValue = ToontownPropertyNormalizer.NormalizeForDocument(propertyMatch.Groups[2].Value);
                 stack.Peek().Properties[propKey] = propValue;
+            }
+
+            if (!sawObjectsScope)
+            {
+                document.Warnings.Add(
+                    "No 'Objects' dictionary scope was detected. Verify source format assumptions for this file.");
             }
 
             var likelyObjects = parsedNodes.Where(IsLikelyWorldObject).ToList();
@@ -289,6 +322,12 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
             public string ParentId;
             public int Indent;
             public Dictionary<string, string> Properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private sealed class DictScope
+        {
+            public int Indent;
+            public bool IsObjectsScope;
         }
     }
 }

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs
@@ -122,7 +122,7 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
                 }
 
                 string propKey = propertyMatch.Groups[1].Value.Trim();
-                string propValue = propertyMatch.Groups[2].Value.Trim();
+                string propValue = ToontownPropertyNormalizer.NormalizeForDocument(propertyMatch.Groups[2].Value);
                 stack.Peek().Properties[propKey] = propValue;
             }
 

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Toolkit.Editor.WorldData.Contracts;
@@ -95,9 +94,7 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
 
             sb.AppendLine($"{indent}'{EscapeSingleQuote(obj.Id)}': {{");
 
-            var orderedProperties = obj.Properties
-                .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            var orderedProperties = ToontownPropertyOrdering.Sort(obj.Properties);
 
             for (int i = 0; i < orderedProperties.Count; i++)
             {

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
@@ -1,10 +1,20 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Toolkit.Editor.WorldData.Contracts;
 
 namespace Toolkit.Editor.WorldData.Adapters.Toontown
 {
     public sealed class ToontownWorldDataDocumentWriter : IWorldDataDocumentWriter
     {
+        private static readonly Regex NumericRegex = new Regex(
+            @"^[-+]?(?:\d+\.?\d*|\.\d+)$",
+            RegexOptions.Compiled);
+
         public string FormatId => "toontown.py.zone";
 
         public bool CanWrite(string outputPath)
@@ -14,8 +24,146 @@ namespace Toolkit.Editor.WorldData.Adapters.Toontown
 
         public void WriteToFile(WorldDataDocument document, string outputPath)
         {
-            throw new NotSupportedException(
-                "Toontown document writer is a scaffold and has not been implemented yet.");
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (!CanWrite(outputPath))
+            {
+                throw new NotSupportedException($"Unsupported output file type: {outputPath}");
+            }
+
+            var byParent = BuildChildrenLookup(document.Objects);
+            var allIds = new HashSet<string>(document.Objects.Select(o => o.Id), StringComparer.OrdinalIgnoreCase);
+            var roots = document.Objects
+                .Where(o => string.IsNullOrWhiteSpace(o.ParentId) || !allIds.Contains(o.ParentId))
+                .ToList();
+
+            var sb = new StringBuilder();
+            sb.AppendLine("objectStruct = {");
+            sb.AppendLine("    'Objects': {");
+
+            for (int i = 0; i < roots.Count; i++)
+            {
+                WriteObjectRecursive(sb, roots[i], byParent, 2, i == roots.Count - 1);
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+
+            string directory = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(outputPath, sb.ToString());
+        }
+
+        private static Dictionary<string, List<WorldDataObject>> BuildChildrenLookup(List<WorldDataObject> objects)
+        {
+            var lookup = new Dictionary<string, List<WorldDataObject>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var obj in objects)
+            {
+                if (string.IsNullOrWhiteSpace(obj.ParentId))
+                {
+                    continue;
+                }
+
+                if (!lookup.TryGetValue(obj.ParentId, out var children))
+                {
+                    children = new List<WorldDataObject>();
+                    lookup[obj.ParentId] = children;
+                }
+
+                children.Add(obj);
+            }
+
+            return lookup;
+        }
+
+        private static void WriteObjectRecursive(
+            StringBuilder sb,
+            WorldDataObject obj,
+            Dictionary<string, List<WorldDataObject>> byParent,
+            int indentLevel,
+            bool isLast)
+        {
+            string indent = new string(' ', indentLevel * 4);
+            string inner = new string(' ', (indentLevel + 1) * 4);
+
+            sb.AppendLine($"{indent}'{EscapeSingleQuote(obj.Id)}': {{");
+
+            var orderedProperties = obj.Properties
+                .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            for (int i = 0; i < orderedProperties.Count; i++)
+            {
+                bool needsComma = i < orderedProperties.Count - 1 || byParent.ContainsKey(obj.Id);
+                string key = EscapeSingleQuote(orderedProperties[i].Key);
+                string value = FormatPythonValue(orderedProperties[i].Value);
+                sb.AppendLine($"{inner}'{key}': {value}{(needsComma ? "," : string.Empty)}");
+            }
+
+            if (byParent.TryGetValue(obj.Id, out var children) && children.Count > 0)
+            {
+                sb.AppendLine($"{inner}'Objects': {{");
+                for (int i = 0; i < children.Count; i++)
+                {
+                    WriteObjectRecursive(sb, children[i], byParent, indentLevel + 2, i == children.Count - 1);
+                }
+                sb.AppendLine($"{inner}}}");
+            }
+
+            sb.AppendLine($"{indent}}}{(isLast ? string.Empty : ",")}");
+        }
+
+        private static string FormatPythonValue(string value)
+        {
+            if (value == null)
+            {
+                return "None";
+            }
+
+            string trimmed = value.Trim();
+            if (trimmed.Length == 0)
+            {
+                return "''";
+            }
+
+            if (trimmed.StartsWith("'") && trimmed.EndsWith("'"))
+            {
+                return trimmed;
+            }
+
+            if (trimmed.StartsWith("\"") && trimmed.EndsWith("\""))
+            {
+                return trimmed;
+            }
+
+            if (trimmed == "True" || trimmed == "False" || trimmed == "None")
+            {
+                return trimmed;
+            }
+
+            if (NumericRegex.IsMatch(trimmed))
+            {
+                return double.Parse(trimmed, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (trimmed.EndsWith(")") || trimmed.StartsWith("(") || trimmed.StartsWith("["))
+            {
+                return trimmed;
+            }
+
+            return $"'{EscapeSingleQuote(trimmed)}'";
+        }
+
+        private static string EscapeSingleQuote(string input)
+        {
+            return input.Replace("\\", "\\\\").Replace("'", "\\'");
         }
     }
 }

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Toolkit.Editor.WorldData.Contracts;

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs
@@ -1,0 +1,21 @@
+using System;
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData.Adapters.Toontown
+{
+    public sealed class ToontownWorldDataDocumentWriter : IWorldDataDocumentWriter
+    {
+        public string FormatId => "toontown.py.zone";
+
+        public bool CanWrite(string outputPath)
+        {
+            return !string.IsNullOrWhiteSpace(outputPath) && outputPath.EndsWith(".py", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void WriteToFile(WorldDataDocument document, string outputPath)
+        {
+            throw new NotSupportedException(
+                "Toontown document writer is a scaffold and has not been implemented yet.");
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataFormatAdapter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataFormatAdapter.cs
@@ -1,0 +1,14 @@
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData.Adapters.Toontown
+{
+    public sealed class ToontownWorldDataFormatAdapter : IWorldDataFormatAdapter
+    {
+        private static readonly IWorldDataDocumentReader ReaderInstance = new ToontownWorldDataDocumentReader();
+        private static readonly IWorldDataDocumentWriter WriterInstance = new ToontownWorldDataDocumentWriter();
+
+        public string FormatId => "toontown.py.zone";
+        public IWorldDataDocumentReader Reader => ReaderInstance;
+        public IWorldDataDocumentWriter Writer => WriterInstance;
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Contracts/IWorldDataDocumentReader.cs
+++ b/Assets/Editor/Toolkit/WorldData/Contracts/IWorldDataDocumentReader.cs
@@ -1,0 +1,9 @@
+namespace Toolkit.Editor.WorldData.Contracts
+{
+    public interface IWorldDataDocumentReader
+    {
+        string FormatId { get; }
+        bool CanRead(string sourcePath);
+        WorldDataDocument ReadFromFile(string sourcePath);
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Contracts/IWorldDataDocumentWriter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Contracts/IWorldDataDocumentWriter.cs
@@ -1,0 +1,9 @@
+namespace Toolkit.Editor.WorldData.Contracts
+{
+    public interface IWorldDataDocumentWriter
+    {
+        string FormatId { get; }
+        bool CanWrite(string outputPath);
+        void WriteToFile(WorldDataDocument document, string outputPath);
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Contracts/IWorldDataFormatAdapter.cs
+++ b/Assets/Editor/Toolkit/WorldData/Contracts/IWorldDataFormatAdapter.cs
@@ -1,0 +1,9 @@
+namespace Toolkit.Editor.WorldData.Contracts
+{
+    public interface IWorldDataFormatAdapter
+    {
+        string FormatId { get; }
+        IWorldDataDocumentReader Reader { get; }
+        IWorldDataDocumentWriter Writer { get; }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Contracts/WorldDataDocument.cs
+++ b/Assets/Editor/Toolkit/WorldData/Contracts/WorldDataDocument.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Toolkit.Editor.WorldData.Contracts
+{
+    public sealed class WorldDataDocument
+    {
+        public string Name;
+        public List<WorldDataObject> Objects = new List<WorldDataObject>();
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/Contracts/WorldDataDocument.cs
+++ b/Assets/Editor/Toolkit/WorldData/Contracts/WorldDataDocument.cs
@@ -6,5 +6,6 @@ namespace Toolkit.Editor.WorldData.Contracts
     {
         public string Name;
         public List<WorldDataObject> Objects = new List<WorldDataObject>();
+        public List<string> Warnings = new List<string>();
     }
 }

--- a/Assets/Editor/Toolkit/WorldData/Contracts/WorldDataObject.cs
+++ b/Assets/Editor/Toolkit/WorldData/Contracts/WorldDataObject.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Toolkit.Editor.WorldData.Contracts
+{
+    public sealed class WorldDataObject
+    {
+        public string Id;
+        public string ParentId;
+        public Dictionary<string, string> Properties = new Dictionary<string, string>();
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/IWorldDataToolLauncher.cs
+++ b/Assets/Editor/Toolkit/WorldData/IWorldDataToolLauncher.cs
@@ -1,0 +1,12 @@
+namespace Toolkit.Editor.WorldData
+{
+    public interface IWorldDataToolLauncher
+    {
+        string DisplayName { get; }
+        string ImporterMenuPath { get; }
+        string ExporterMenuPath { get; }
+
+        bool OpenImporter();
+        bool OpenExporter();
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/IWorldDataToolRoute.cs
+++ b/Assets/Editor/Toolkit/WorldData/IWorldDataToolRoute.cs
@@ -1,0 +1,9 @@
+namespace Toolkit.Editor.WorldData
+{
+    public interface IWorldDataToolRoute
+    {
+        string DisplayName { get; }
+        string ImporterMenuPath { get; }
+        string ExporterMenuPath { get; }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/PotcoWorldDataToolLauncher.cs
+++ b/Assets/Editor/Toolkit/WorldData/PotcoWorldDataToolLauncher.cs
@@ -1,0 +1,23 @@
+using UnityEditor;
+
+namespace Toolkit.Editor.WorldData
+{
+    public sealed class PotcoWorldDataToolLauncher : IWorldDataToolLauncher
+    {
+        private static readonly IWorldDataToolRoute Route = new PotcoWorldDataToolRoute();
+
+        public string DisplayName => Route.DisplayName;
+        public string ImporterMenuPath => Route.ImporterMenuPath;
+        public string ExporterMenuPath => Route.ExporterMenuPath;
+
+        public bool OpenImporter()
+        {
+            return EditorApplication.ExecuteMenuItem(ImporterMenuPath);
+        }
+
+        public bool OpenExporter()
+        {
+            return EditorApplication.ExecuteMenuItem(ExporterMenuPath);
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/PotcoWorldDataToolRoute.cs
+++ b/Assets/Editor/Toolkit/WorldData/PotcoWorldDataToolRoute.cs
@@ -1,0 +1,11 @@
+using Toolkit.Core;
+
+namespace Toolkit.Editor.WorldData
+{
+    public sealed class PotcoWorldDataToolRoute : IWorldDataToolRoute
+    {
+        public string DisplayName => GameFlavor.POTCO.ToString();
+        public string ImporterMenuPath => "POTCO/World Data/Importer";
+        public string ExporterMenuPath => "POTCO/World Data/Exporter";
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/ToolkitWorldDataMenu.cs
+++ b/Assets/Editor/Toolkit/WorldData/ToolkitWorldDataMenu.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Toolkit.Editor.WorldData
+{
+    public static class ToolkitWorldDataMenu
+    {
+        [MenuItem("Toolkit/World Data/Open Importer")]
+        public static void OpenImporter()
+        {
+            var launcher = WorldDataToolLauncherRegistry.GetActiveLauncher();
+            if (!launcher.OpenImporter())
+            {
+                Debug.LogError($"Failed to open importer: {launcher.ImporterMenuPath}");
+            }
+        }
+
+        [MenuItem("Toolkit/World Data/Open Exporter")]
+        public static void OpenExporter()
+        {
+            var launcher = WorldDataToolLauncherRegistry.GetActiveLauncher();
+            if (!launcher.OpenExporter())
+            {
+                Debug.LogError($"Failed to open exporter: {launcher.ExporterMenuPath}");
+            }
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/ToontownWorldDataToolLauncher.cs
+++ b/Assets/Editor/Toolkit/WorldData/ToontownWorldDataToolLauncher.cs
@@ -1,0 +1,23 @@
+using UnityEditor;
+
+namespace Toolkit.Editor.WorldData
+{
+    public sealed class ToontownWorldDataToolLauncher : IWorldDataToolLauncher
+    {
+        private static readonly IWorldDataToolRoute Route = new ToontownWorldDataToolRoute();
+
+        public string DisplayName => Route.DisplayName;
+        public string ImporterMenuPath => Route.ImporterMenuPath;
+        public string ExporterMenuPath => Route.ExporterMenuPath;
+
+        public bool OpenImporter()
+        {
+            return EditorApplication.ExecuteMenuItem(ImporterMenuPath);
+        }
+
+        public bool OpenExporter()
+        {
+            return EditorApplication.ExecuteMenuItem(ExporterMenuPath);
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/ToontownWorldDataToolRoute.cs
+++ b/Assets/Editor/Toolkit/WorldData/ToontownWorldDataToolRoute.cs
@@ -1,0 +1,11 @@
+using Toolkit.Core;
+
+namespace Toolkit.Editor.WorldData
+{
+    public sealed class ToontownWorldDataToolRoute : IWorldDataToolRoute
+    {
+        public string DisplayName => GameFlavor.Toontown.ToString();
+        public string ImporterMenuPath => "Toontown/World Data/Importer";
+        public string ExporterMenuPath => "Toontown/World Data/Exporter";
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/WorldDataFormatAdapterRegistry.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataFormatAdapterRegistry.cs
@@ -1,0 +1,20 @@
+using Toolkit.Core;
+using Toolkit.Editor.WorldData.Adapters.Potco;
+using Toolkit.Editor.WorldData.Adapters.Toontown;
+using Toolkit.Editor.WorldData.Contracts;
+
+namespace Toolkit.Editor.WorldData
+{
+    public static class WorldDataFormatAdapterRegistry
+    {
+        private static readonly IWorldDataFormatAdapter PotcoAdapter = new PotcoWorldDataFormatAdapter();
+        private static readonly IWorldDataFormatAdapter ToontownAdapter = new ToontownWorldDataFormatAdapter();
+
+        public static IWorldDataFormatAdapter GetActiveAdapter()
+        {
+            return WorldDataToolRouteResolver.GetActiveGameFlavor() == GameFlavor.Toontown
+                ? ToontownAdapter
+                : PotcoAdapter;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs
@@ -1,0 +1,55 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Toolkit.Editor.WorldData
+{
+    public sealed class WorldDataRouterWindow : EditorWindow
+    {
+        [MenuItem("Toolkit/World Data/Router")]
+        public static void ShowWindow()
+        {
+            GetWindow<WorldDataRouterWindow>("World Data Router");
+        }
+
+        private void OnGUI()
+        {
+            var route = WorldDataToolRouteResolver.ResolveActiveRoute();
+            EditorGUILayout.LabelField("World Data Router", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField("Active Route", route.DisplayName);
+            EditorGUILayout.LabelField("Importer Menu", route.ImporterMenuPath);
+            EditorGUILayout.LabelField("Exporter Menu", route.ExporterMenuPath);
+            EditorGUILayout.Space();
+
+            if (GUILayout.Button("Open Active Importer"))
+            {
+                if (!EditorApplication.ExecuteMenuItem(route.ImporterMenuPath))
+                {
+                    Debug.LogError($"Could not open importer menu path: {route.ImporterMenuPath}");
+                }
+            }
+
+            if (GUILayout.Button("Open Active Exporter"))
+            {
+                if (!EditorApplication.ExecuteMenuItem(route.ExporterMenuPath))
+                {
+                    Debug.LogError($"Could not open exporter menu path: {route.ExporterMenuPath}");
+                }
+            }
+
+            EditorGUILayout.Space();
+            if (GUILayout.Button("Open Toolkit Settings"))
+            {
+                if (!EditorApplication.ExecuteMenuItem("Toolkit/Settings"))
+                {
+                    Debug.LogError("Could not open Toolkit/Settings.");
+                }
+            }
+
+            EditorGUILayout.HelpBox(
+                "Set the active game in Toolkit/Settings. This router keeps POTCO tools unchanged while enabling Toontown-specific entry points.",
+                MessageType.Info);
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs
@@ -13,30 +13,30 @@ namespace Toolkit.Editor.WorldData
 
         private void OnGUI()
         {
-            var route = WorldDataToolRouteResolver.ResolveActiveRoute();
+            var launcher = WorldDataToolLauncherRegistry.GetActiveLauncher();
             var adapter = WorldDataFormatAdapterRegistry.GetActiveAdapter();
             EditorGUILayout.LabelField("World Data Router", EditorStyles.boldLabel);
             EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField("Active Route", route.DisplayName);
-            EditorGUILayout.LabelField("Importer Menu", route.ImporterMenuPath);
-            EditorGUILayout.LabelField("Exporter Menu", route.ExporterMenuPath);
+            EditorGUILayout.LabelField("Active Route", launcher.DisplayName);
+            EditorGUILayout.LabelField("Importer Menu", launcher.ImporterMenuPath);
+            EditorGUILayout.LabelField("Exporter Menu", launcher.ExporterMenuPath);
             EditorGUILayout.LabelField("Format Adapter", adapter.FormatId);
             EditorGUILayout.Space();
 
             if (GUILayout.Button("Open Active Importer"))
             {
-                if (!EditorApplication.ExecuteMenuItem(route.ImporterMenuPath))
+                if (!launcher.OpenImporter())
                 {
-                    Debug.LogError($"Could not open importer menu path: {route.ImporterMenuPath}");
+                    Debug.LogError($"Could not open importer menu path: {launcher.ImporterMenuPath}");
                 }
             }
 
             if (GUILayout.Button("Open Active Exporter"))
             {
-                if (!EditorApplication.ExecuteMenuItem(route.ExporterMenuPath))
+                if (!launcher.OpenExporter())
                 {
-                    Debug.LogError($"Could not open exporter menu path: {route.ExporterMenuPath}");
+                    Debug.LogError($"Could not open exporter menu path: {launcher.ExporterMenuPath}");
                 }
             }
 

--- a/Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs
@@ -14,12 +14,14 @@ namespace Toolkit.Editor.WorldData
         private void OnGUI()
         {
             var route = WorldDataToolRouteResolver.ResolveActiveRoute();
+            var adapter = WorldDataFormatAdapterRegistry.GetActiveAdapter();
             EditorGUILayout.LabelField("World Data Router", EditorStyles.boldLabel);
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Active Route", route.DisplayName);
             EditorGUILayout.LabelField("Importer Menu", route.ImporterMenuPath);
             EditorGUILayout.LabelField("Exporter Menu", route.ExporterMenuPath);
+            EditorGUILayout.LabelField("Format Adapter", adapter.FormatId);
             EditorGUILayout.Space();
 
             if (GUILayout.Button("Open Active Importer"))

--- a/Assets/Editor/Toolkit/WorldData/WorldDataToolLauncherRegistry.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataToolLauncherRegistry.cs
@@ -1,0 +1,17 @@
+using Toolkit.Core;
+
+namespace Toolkit.Editor.WorldData
+{
+    public static class WorldDataToolLauncherRegistry
+    {
+        private static readonly IWorldDataToolLauncher PotcoLauncher = new PotcoWorldDataToolLauncher();
+        private static readonly IWorldDataToolLauncher ToontownLauncher = new ToontownWorldDataToolLauncher();
+
+        public static IWorldDataToolLauncher GetActiveLauncher()
+        {
+            return WorldDataToolRouteResolver.GetActiveGameFlavor() == GameFlavor.Toontown
+                ? ToontownLauncher
+                : PotcoLauncher;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/WorldDataToolRouteResolver.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataToolRouteResolver.cs
@@ -1,0 +1,23 @@
+using Toolkit.Core;
+using UnityEditor;
+
+namespace Toolkit.Editor.WorldData
+{
+    public static class WorldDataToolRouteResolver
+    {
+        private const string SettingsAssetPath = "Assets/Resources/Toolkit/ToolkitProjectSettings.asset";
+        private static readonly IWorldDataToolRoute PotcoRoute = new PotcoWorldDataToolRoute();
+        private static readonly IWorldDataToolRoute ToontownRoute = new ToontownWorldDataToolRoute();
+
+        public static IWorldDataToolRoute ResolveActiveRoute()
+        {
+            var settings = AssetDatabase.LoadAssetAtPath<ToolkitProjectSettings>(SettingsAssetPath);
+            if (settings == null)
+            {
+                return PotcoRoute;
+            }
+
+            return settings.activeGameFlavor == GameFlavor.Toontown ? ToontownRoute : PotcoRoute;
+        }
+    }
+}

--- a/Assets/Editor/Toolkit/WorldData/WorldDataToolRouteResolver.cs
+++ b/Assets/Editor/Toolkit/WorldData/WorldDataToolRouteResolver.cs
@@ -9,15 +9,20 @@ namespace Toolkit.Editor.WorldData
         private static readonly IWorldDataToolRoute PotcoRoute = new PotcoWorldDataToolRoute();
         private static readonly IWorldDataToolRoute ToontownRoute = new ToontownWorldDataToolRoute();
 
-        public static IWorldDataToolRoute ResolveActiveRoute()
+        public static GameFlavor GetActiveGameFlavor()
         {
             var settings = AssetDatabase.LoadAssetAtPath<ToolkitProjectSettings>(SettingsAssetPath);
             if (settings == null)
             {
-                return PotcoRoute;
+                return GameFlavor.POTCO;
             }
 
-            return settings.activeGameFlavor == GameFlavor.Toontown ? ToontownRoute : PotcoRoute;
+            return settings.activeGameFlavor;
+        }
+
+        public static IWorldDataToolRoute ResolveActiveRoute()
+        {
+            return GetActiveGameFlavor() == GameFlavor.Toontown ? ToontownRoute : PotcoRoute;
         }
     }
 }

--- a/Assets/Editor/Toontown/Config/ObjectTypeMap.json
+++ b/Assets/Editor/Toontown/Config/ObjectTypeMap.json
@@ -1,0 +1,25 @@
+{
+  "defaultType": "Unknown",
+  "rules": [
+    {
+      "modelContains": "models/props/",
+      "type": "Prop"
+    },
+    {
+      "modelContains": "models/buildings/",
+      "type": "Building"
+    },
+    {
+      "modelContains": "models/char/",
+      "type": "Character"
+    },
+    {
+      "modelContains": "models/streets/",
+      "type": "Street"
+    },
+    {
+      "modelContains": "models/neighborhoods/",
+      "type": "Neighborhood"
+    }
+  ]
+}

--- a/Assets/Editor/Toontown/Samples/toontown_sample_world.py
+++ b/Assets/Editor/Toontown/Samples/toontown_sample_world.py
@@ -1,0 +1,27 @@
+from pandac.PandaModules import Point3, VBase3
+
+objectStruct = {
+    'Objects': {
+        'sample-zone-root': {
+            'Type': 'Street',
+            'Name': 'Sample Zone Root',
+            'Pos': Point3(0.0, 0.0, 0.0),
+            'Hpr': VBase3(0.0, 0.0, 0.0),
+            'Scale': VBase3(1.0, 1.0, 1.0),
+            'Visual': {
+                'Model': 'phase_4/models/neighborhoods/sz_grounds' },
+            'Objects': {
+                'sample-prop-01': {
+                    'Name': 'Mailbox',
+                    'Pos': Point3(4.5, 2.0, 0.0),
+                    'Hpr': VBase3(90.0, 0.0, 0.0),
+                    'Scale': VBase3(1.0, 1.0, 1.0),
+                    'Visual': {
+                        'Model': 'phase_4/models/props/mailbox' } },
+                'sample-prop-02': {
+                    'Name': 'Bench',
+                    'Pos': Point3(-3.0, 1.0, 0.0),
+                    'Hpr': VBase3(180.0, 0.0, 0.0),
+                    'Scale': VBase3(1.0, 1.0, 1.0),
+                    'Visual': {
+                        'Model': 'phase_4/models/props/park_bench' } } } } } }

--- a/Assets/Editor/Toontown/ToontownQuickStartWindow.cs
+++ b/Assets/Editor/Toontown/ToontownQuickStartWindow.cs
@@ -1,0 +1,109 @@
+using Toolkit.Core;
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+namespace Toontown.Editor
+{
+    public sealed class ToontownQuickStartWindow : EditorWindow
+    {
+        private const string SettingsDirectory = "Assets/Resources/Toolkit";
+        private const string SettingsAssetPath = SettingsDirectory + "/ToolkitProjectSettings.asset";
+        private string statusMessage = "Use this window to launch the first Toontown workflow.";
+
+        [MenuItem("Toontown/Quick Start")]
+        public static void ShowWindow()
+        {
+            GetWindow<ToontownQuickStartWindow>("Toontown Quick Start");
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Toontown Quick Start", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "Goal: get to a working parse/export cycle with bundled sample data in a few clicks.",
+                MessageType.Info);
+
+            EditorGUILayout.Space();
+            if (GUILayout.Button("1) Switch Active Game Flavor to Toontown"))
+            {
+                SwitchActiveFlavorToToontown();
+            }
+
+            if (GUILayout.Button("2) Open Toontown Importer"))
+            {
+                ToontownWorldDataImporter.ShowWindow();
+                statusMessage = "Opened Toontown importer.";
+            }
+
+            if (GUILayout.Button("3) Open Toontown Exporter"))
+            {
+                ToontownWorldDataExporter.ShowWindow();
+                statusMessage = "Opened Toontown exporter.";
+            }
+
+            if (GUILayout.Button("4) Open Sample Validator"))
+            {
+                Validation.ToontownSampleValidationWindow.ShowWindow();
+                statusMessage = "Opened Toontown sample validator.";
+            }
+
+            if (GUILayout.Button("5) Reveal Bundled Sample File"))
+            {
+                if (!ToontownToolkitPaths.BundledSampleExists())
+                {
+                    statusMessage =
+                        $"Bundled sample not found at {ToontownToolkitPaths.BundledSampleRelativePath}.";
+                }
+                else
+                {
+                    EditorUtility.RevealInFinder(ToontownToolkitPaths.BundledSampleFullPath);
+                    statusMessage = "Opened file explorer at bundled sample location.";
+                }
+            }
+
+            if (GUILayout.Button("Open Quick Start Doc"))
+            {
+                EditorUtility.OpenWithDefaultApp(Path.Combine(Directory.GetCurrentDirectory(), "docs/TOONTOWN_QUICKSTART.md"));
+                statusMessage = "Opened docs/TOONTOWN_QUICKSTART.md";
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(statusMessage, MessageType.None);
+        }
+
+        private void SwitchActiveFlavorToToontown()
+        {
+            ToolkitProjectSettings settings = LoadOrCreateSettings();
+            settings.activeGameFlavor = GameFlavor.Toontown;
+            EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
+            statusMessage = "Active game flavor set to Toontown.";
+        }
+
+        private static ToolkitProjectSettings LoadOrCreateSettings()
+        {
+            var asset = AssetDatabase.LoadAssetAtPath<ToolkitProjectSettings>(SettingsAssetPath);
+            if (asset != null)
+            {
+                return asset;
+            }
+
+            if (!AssetDatabase.IsValidFolder("Assets/Resources"))
+            {
+                AssetDatabase.CreateFolder("Assets", "Resources");
+            }
+
+            if (!AssetDatabase.IsValidFolder(SettingsDirectory))
+            {
+                AssetDatabase.CreateFolder("Assets/Resources", "Toolkit");
+            }
+
+            asset = CreateInstance<ToolkitProjectSettings>();
+            AssetDatabase.CreateAsset(asset, SettingsAssetPath);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            return asset;
+        }
+    }
+}

--- a/Assets/Editor/Toontown/ToontownToolkitPaths.cs
+++ b/Assets/Editor/Toontown/ToontownToolkitPaths.cs
@@ -1,0 +1,34 @@
+using System.IO;
+
+namespace Toontown.Editor
+{
+    internal static class ToontownToolkitPaths
+    {
+        public const string BundledSampleRelativePath = "Assets/Editor/Toontown/Samples/toontown_sample_world.py";
+        public const string SuggestedExportRelativePath = "Assets/Editor/Toontown/Samples/Generated/toontown_sample_export.py";
+
+        public static string BundledSampleFullPath => ToFullPath(BundledSampleRelativePath);
+        public static string SuggestedExportFullPath => ToFullPath(SuggestedExportRelativePath);
+
+        public static bool BundledSampleExists()
+        {
+            return File.Exists(BundledSampleFullPath);
+        }
+
+        public static void EnsureSuggestedExportDirectoryExists()
+        {
+            string directory = Path.GetDirectoryName(SuggestedExportFullPath);
+            if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+        }
+
+        private static string ToFullPath(string relativePath)
+        {
+            return Path.Combine(
+                Directory.GetCurrentDirectory(),
+                relativePath.Replace('/', Path.DirectorySeparatorChar));
+        }
+    }
+}

--- a/Assets/Editor/Toontown/Validation/ToontownSampleSmokeTestRunner.cs
+++ b/Assets/Editor/Toontown/Validation/ToontownSampleSmokeTestRunner.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using System.Text;
+using Toolkit.Editor.WorldData.Adapters.Toontown;
+using Toolkit.Editor.WorldData.Contracts;
+using UnityEditor;
+using UnityEngine;
+
+namespace Toontown.Editor.Validation
+{
+    public static class ToontownSampleSmokeTestRunner
+    {
+        [MenuItem("Toontown/Validation/Run Sample Smoke Test")]
+        public static void Run()
+        {
+            if (!ToontownToolkitPaths.BundledSampleExists())
+            {
+                string missing =
+                    $"Bundled sample not found at {ToontownToolkitPaths.BundledSampleRelativePath}.";
+                Debug.LogError(missing);
+                EditorUtility.DisplayDialog("Toontown Smoke Test", missing, "OK");
+                return;
+            }
+
+            string source = ToontownToolkitPaths.BundledSampleFullPath;
+            ToontownToolkitPaths.EnsureSuggestedExportDirectoryExists();
+            string output = ToontownToolkitPaths.SuggestedExportFullPath;
+
+            var reader = new ToontownWorldDataDocumentReader();
+            var writer = new ToontownWorldDataDocumentWriter();
+
+            WorldDataDocument inputDoc;
+            WorldDataDocument outputDoc;
+
+            try
+            {
+                inputDoc = reader.ReadFromFile(source);
+                writer.WriteToFile(inputDoc, output);
+                outputDoc = reader.ReadFromFile(output);
+            }
+            catch (System.Exception ex)
+            {
+                string failure = $"Smoke test failed: {ex.Message}";
+                Debug.LogError(failure);
+                EditorUtility.DisplayDialog("Toontown Smoke Test", failure, "OK");
+                return;
+            }
+
+            bool countMatch = inputDoc.Objects.Count == outputDoc.Objects.Count;
+            string status = countMatch ? "PASS" : "WARN";
+
+            var report = new StringBuilder();
+            report.AppendLine("Toontown Sample Smoke Test");
+            report.AppendLine($"Status: {status}");
+            report.AppendLine($"Source: {source}");
+            report.AppendLine($"Output: {output}");
+            report.AppendLine($"Input objects: {inputDoc.Objects.Count}");
+            report.AppendLine($"Output objects: {outputDoc.Objects.Count}");
+            report.AppendLine($"Input warnings: {inputDoc.Warnings.Count}");
+            report.AppendLine($"Output warnings: {outputDoc.Warnings.Count}");
+
+            if (!countMatch)
+            {
+                report.AppendLine("Round-trip object count mismatch detected.");
+            }
+
+            if (File.Exists(output))
+            {
+                report.AppendLine($"Output file size: {new FileInfo(output).Length} bytes");
+            }
+
+            Debug.Log(report.ToString());
+            EditorUtility.DisplayDialog("Toontown Smoke Test", $"Completed with status: {status}", "OK");
+        }
+    }
+}

--- a/Assets/Editor/Toontown/Validation/ToontownSampleSmokeTestRunner.cs
+++ b/Assets/Editor/Toontown/Validation/ToontownSampleSmokeTestRunner.cs
@@ -17,7 +17,7 @@ namespace Toontown.Editor.Validation
                 string missing =
                     $"Bundled sample not found at {ToontownToolkitPaths.BundledSampleRelativePath}.";
                 Debug.LogError(missing);
-                EditorUtility.DisplayDialog("Toontown Smoke Test", missing, "OK");
+                ShowDialogIfInteractive("Toontown Smoke Test", missing);
                 return;
             }
 
@@ -41,7 +41,7 @@ namespace Toontown.Editor.Validation
             {
                 string failure = $"Smoke test failed: {ex.Message}";
                 Debug.LogError(failure);
-                EditorUtility.DisplayDialog("Toontown Smoke Test", failure, "OK");
+                ShowDialogIfInteractive("Toontown Smoke Test", failure);
                 return;
             }
 
@@ -69,7 +69,17 @@ namespace Toontown.Editor.Validation
             }
 
             Debug.Log(report.ToString());
-            EditorUtility.DisplayDialog("Toontown Smoke Test", $"Completed with status: {status}", "OK");
+            ShowDialogIfInteractive("Toontown Smoke Test", $"Completed with status: {status}");
+        }
+
+        private static void ShowDialogIfInteractive(string title, string message)
+        {
+            if (Application.isBatchMode)
+            {
+                return;
+            }
+
+            EditorUtility.DisplayDialog(title, message, "OK");
         }
     }
 }

--- a/Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs
+++ b/Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs
@@ -94,6 +94,13 @@ namespace Toontown.Editor.Validation
                 EditorUtility.OpenWithDefaultApp(ToontownObjectTypeMapper.ConfigFullPath);
             }
 
+            EditorGUI.BeginDisabledGroup(results.Count == 0);
+            if (GUILayout.Button("Export CSV Report"))
+            {
+                ExportCsvReport();
+            }
+            EditorGUI.EndDisabledGroup();
+
             if (GUILayout.Button("Clear Results"))
             {
                 results.Clear();
@@ -269,6 +276,62 @@ namespace Toontown.Editor.Validation
 
             EditorGUILayout.EndScrollView();
             EditorGUILayout.EndVertical();
+        }
+
+        private void ExportCsvReport()
+        {
+            string path = EditorUtility.SaveFilePanel(
+                "Export Validation Report",
+                Application.dataPath,
+                "toontown_validation_report.csv",
+                "csv");
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                statusMessage = "CSV export cancelled.";
+                return;
+            }
+
+            try
+            {
+                using (var writer = new StreamWriter(path, false))
+                {
+                    writer.WriteLine(
+                        "FileName,Quality,ObjectCount,UnknownTypeRatio,UnknownTypeCount,DuplicateIdGroups,WarningCount,ObjectsWithModel,ObjectsWithType,ParseError");
+
+                    foreach (var r in results)
+                    {
+                        writer.WriteLine(
+                            $"{Csv(r.FileName)}," +
+                            $"{Csv(r.Quality)}," +
+                            $"{r.ObjectCount}," +
+                            $"{r.UnknownTypeRatio:0.####}," +
+                            $"{r.UnknownTypeCount}," +
+                            $"{r.DuplicateIdGroups}," +
+                            $"{r.WarningCount}," +
+                            $"{r.ObjectsWithModel}," +
+                            $"{r.ObjectsWithType}," +
+                            $"{Csv(r.ParseError)}");
+                    }
+                }
+
+                statusMessage = $"Exported CSV report: {path}";
+            }
+            catch (Exception ex)
+            {
+                statusMessage = $"CSV export failed: {ex.Message}";
+            }
+        }
+
+        private static string Csv(string input)
+        {
+            if (input == null)
+            {
+                return "\"\"";
+            }
+
+            string escaped = input.Replace("\"", "\"\"");
+            return $"\"{escaped}\"";
         }
 
         private sealed class ValidationResult

--- a/Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs
+++ b/Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs
@@ -81,6 +81,11 @@ namespace Toontown.Editor.Validation
             }
             EditorGUI.EndDisabledGroup();
 
+            if (GUILayout.Button("Validate Bundled Sample"))
+            {
+                ValidateBundledSample();
+            }
+
             EditorGUI.BeginDisabledGroup(string.IsNullOrWhiteSpace(selectedFolderPath));
             if (GUILayout.Button("Validate Folder"))
             {
@@ -106,6 +111,19 @@ namespace Toontown.Editor.Validation
                 results.Clear();
                 statusMessage = "Validation results cleared.";
             }
+        }
+
+        private void ValidateBundledSample()
+        {
+            if (!ToontownToolkitPaths.BundledSampleExists())
+            {
+                statusMessage =
+                    $"Bundled sample not found at {ToontownToolkitPaths.BundledSampleRelativePath}.";
+                return;
+            }
+
+            selectedFilePath = ToontownToolkitPaths.BundledSampleFullPath;
+            ValidateSingleFile(selectedFilePath);
         }
 
         private void ValidateSingleFile(string path)

--- a/Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs
+++ b/Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Toolkit.Editor.WorldData.Adapters.Toontown;
+using Toolkit.Editor.WorldData.Contracts;
+using UnityEditor;
+using UnityEngine;
+
+namespace Toontown.Editor.Validation
+{
+    public sealed class ToontownSampleValidationWindow : EditorWindow
+    {
+        private const int MaxFolderFiles = 200;
+
+        private string selectedFilePath;
+        private string selectedFolderPath;
+        private string statusMessage = "Select a file or folder to validate.";
+        private Vector2 scroll;
+        private readonly List<ValidationResult> results = new List<ValidationResult>();
+
+        [MenuItem("Toontown/Validation/Sample Validator")]
+        public static void ShowWindow()
+        {
+            GetWindow<ToontownSampleValidationWindow>("Toontown Validator");
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Toontown Sample Validator", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+
+            DrawSelection();
+            EditorGUILayout.Space();
+            DrawActions();
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(statusMessage, MessageType.Info);
+
+            if (results.Count > 0)
+            {
+                EditorGUILayout.Space();
+                DrawSummary();
+                DrawResults();
+            }
+        }
+
+        private void DrawSelection()
+        {
+            if (GUILayout.Button("Select Sample .py File"))
+            {
+                string selected = EditorUtility.OpenFilePanel("Select Toontown Sample", Application.dataPath, "py");
+                if (!string.IsNullOrWhiteSpace(selected))
+                {
+                    selectedFilePath = selected;
+                    statusMessage = $"Selected sample file: {Path.GetFileName(selectedFilePath)}";
+                }
+            }
+
+            EditorGUILayout.LabelField("Sample File", string.IsNullOrWhiteSpace(selectedFilePath) ? "<none>" : selectedFilePath);
+
+            if (GUILayout.Button("Select Folder (.py Batch)"))
+            {
+                string selected = EditorUtility.OpenFolderPanel("Select Sample Folder", Application.dataPath, string.Empty);
+                if (!string.IsNullOrWhiteSpace(selected))
+                {
+                    selectedFolderPath = selected;
+                    statusMessage = $"Selected folder: {selectedFolderPath}";
+                }
+            }
+
+            EditorGUILayout.LabelField("Sample Folder", string.IsNullOrWhiteSpace(selectedFolderPath) ? "<none>" : selectedFolderPath);
+        }
+
+        private void DrawActions()
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginDisabledGroup(string.IsNullOrWhiteSpace(selectedFilePath));
+            if (GUILayout.Button("Validate Selected File"))
+            {
+                ValidateSingleFile(selectedFilePath);
+            }
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUI.BeginDisabledGroup(string.IsNullOrWhiteSpace(selectedFolderPath));
+            if (GUILayout.Button("Validate Folder"))
+            {
+                ValidateFolder(selectedFolderPath);
+            }
+            EditorGUI.EndDisabledGroup();
+            EditorGUILayout.EndHorizontal();
+
+            if (GUILayout.Button("Open Type Map Config"))
+            {
+                EditorUtility.OpenWithDefaultApp(ToontownObjectTypeMapper.ConfigFullPath);
+            }
+
+            if (GUILayout.Button("Clear Results"))
+            {
+                results.Clear();
+                statusMessage = "Validation results cleared.";
+            }
+        }
+
+        private void ValidateSingleFile(string path)
+        {
+            results.Clear();
+            var result = ValidateFile(path);
+            results.Add(result);
+            statusMessage = $"Validated 1 file: {result.FileName} ({result.Quality}).";
+        }
+
+        private void ValidateFolder(string folderPath)
+        {
+            results.Clear();
+            if (!Directory.Exists(folderPath))
+            {
+                statusMessage = "Selected folder does not exist.";
+                return;
+            }
+
+            string[] files = Directory.GetFiles(folderPath, "*.py", SearchOption.AllDirectories);
+            Array.Sort(files, StringComparer.OrdinalIgnoreCase);
+            if (files.Length == 0)
+            {
+                statusMessage = "No .py files found in selected folder.";
+                return;
+            }
+
+            int takeCount = Mathf.Min(files.Length, MaxFolderFiles);
+            for (int i = 0; i < takeCount; i++)
+            {
+                results.Add(ValidateFile(files[i]));
+            }
+
+            if (files.Length > MaxFolderFiles)
+            {
+                statusMessage =
+                    $"Validated {takeCount}/{files.Length} files (cap {MaxFolderFiles}). Refine folder scope for full coverage.";
+            }
+            else
+            {
+                statusMessage = $"Validated {results.Count} files.";
+            }
+        }
+
+        private static ValidationResult ValidateFile(string path)
+        {
+            var reader = new ToontownWorldDataDocumentReader();
+            var result = new ValidationResult
+            {
+                FilePath = path,
+                FileName = Path.GetFileName(path)
+            };
+
+            try
+            {
+                WorldDataDocument doc = reader.ReadFromFile(path);
+                result.ObjectCount = doc.Objects.Count;
+                result.WarningCount = doc.Warnings.Count;
+
+                int withModel = 0;
+                int withType = 0;
+                int unknownType = 0;
+
+                foreach (var obj in doc.Objects)
+                {
+                    if (obj.Properties.ContainsKey("Model")) withModel++;
+                    if (obj.Properties.ContainsKey("Type"))
+                    {
+                        withType++;
+                        string t = obj.Properties["Type"];
+                        if (string.Equals(t, "Unknown", StringComparison.OrdinalIgnoreCase))
+                        {
+                            unknownType++;
+                        }
+                    }
+                }
+
+                result.ObjectsWithModel = withModel;
+                result.ObjectsWithType = withType;
+                result.UnknownTypeCount = unknownType;
+
+                int duplicateGroups = doc.Objects
+                    .GroupBy(o => o.Id, StringComparer.OrdinalIgnoreCase)
+                    .Count(g => g.Count() > 1);
+                result.DuplicateIdGroups = duplicateGroups;
+
+                result.UnknownTypeRatio = result.ObjectCount > 0
+                    ? (float)result.UnknownTypeCount / result.ObjectCount
+                    : 1f;
+
+                result.Quality = ComputeQuality(result);
+            }
+            catch (Exception ex)
+            {
+                result.Quality = "FAIL";
+                result.ParseError = ex.Message;
+            }
+
+            return result;
+        }
+
+        private static string ComputeQuality(ValidationResult result)
+        {
+            if (!string.IsNullOrWhiteSpace(result.ParseError))
+            {
+                return "FAIL";
+            }
+
+            if (result.ObjectCount == 0)
+            {
+                return "FAIL";
+            }
+
+            if (result.DuplicateIdGroups > 0)
+            {
+                return "FAIL";
+            }
+
+            if (result.UnknownTypeRatio > 0.50f)
+            {
+                return "FAIL";
+            }
+
+            if (result.UnknownTypeRatio > 0.20f || result.WarningCount > 10)
+            {
+                return "WARN";
+            }
+
+            return "PASS";
+        }
+
+        private void DrawSummary()
+        {
+            int totalFiles = results.Count;
+            int pass = results.Count(r => r.Quality == "PASS");
+            int warn = results.Count(r => r.Quality == "WARN");
+            int fail = results.Count(r => r.Quality == "FAIL");
+
+            float avgUnknownRatio = totalFiles > 0 ? results.Average(r => r.UnknownTypeRatio) : 0f;
+
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField("Validation Summary", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Files", totalFiles.ToString());
+            EditorGUILayout.LabelField("PASS", pass.ToString());
+            EditorGUILayout.LabelField("WARN", warn.ToString());
+            EditorGUILayout.LabelField("FAIL", fail.ToString());
+            EditorGUILayout.LabelField("Average Unknown Type Ratio", avgUnknownRatio.ToString("P1"));
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawResults()
+        {
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField("Per-File Results", EditorStyles.boldLabel);
+            scroll = EditorGUILayout.BeginScrollView(scroll, GUILayout.Height(300));
+
+            foreach (var r in results)
+            {
+                string headline =
+                    $"{r.Quality} | {r.FileName} | objs={r.ObjectCount}, unknown={r.UnknownTypeRatio:P1}, dupGroups={r.DuplicateIdGroups}, warnings={r.WarningCount}";
+                EditorGUILayout.LabelField(headline);
+
+                if (!string.IsNullOrWhiteSpace(r.ParseError))
+                {
+                    EditorGUILayout.HelpBox($"Parse error: {r.ParseError}", MessageType.Error);
+                }
+            }
+
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
+        }
+
+        private sealed class ValidationResult
+        {
+            public string FilePath;
+            public string FileName;
+            public int ObjectCount;
+            public int ObjectsWithModel;
+            public int ObjectsWithType;
+            public int UnknownTypeCount;
+            public float UnknownTypeRatio;
+            public int DuplicateIdGroups;
+            public int WarningCount;
+            public string Quality;
+            public string ParseError;
+        }
+    }
+}

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -13,6 +13,7 @@ namespace Toontown.Editor
         private string outputPath;
         private string statusMessage = "Select source and output files.";
         private WorldDataDocument parsedDocument;
+        private WorldDataDocument roundTripDocument;
 
         [MenuItem("Toontown/World Data/Exporter")]
         public static void ShowWindow()
@@ -87,6 +88,14 @@ namespace Toontown.Editor
                 }
             }
 
+            if (roundTripDocument != null)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Round-Trip Validation", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField("Exported Re-Parse Objects", roundTripDocument.Objects.Count.ToString());
+                EditorGUILayout.LabelField("Exported Re-Parse Warnings", roundTripDocument.Warnings.Count.ToString());
+            }
+
             EditorGUILayout.Space();
             if (GUILayout.Button("Open Migration Plan"))
             {
@@ -116,12 +125,22 @@ namespace Toontown.Editor
 
                 parsedDocument = reader.ReadFromFile(sourcePath);
                 writer.WriteToFile(parsedDocument, outputPath);
+                roundTripDocument = reader.ReadFromFile(outputPath);
 
-                statusMessage =
-                    $"Wrote {parsedDocument.Objects.Count} likely objects to {System.IO.Path.GetFileName(outputPath)}.";
+                if (roundTripDocument.Objects.Count != parsedDocument.Objects.Count)
+                {
+                    statusMessage =
+                        $"Wrote file but round-trip object count mismatch: in={parsedDocument.Objects.Count}, out={roundTripDocument.Objects.Count}.";
+                }
+                else
+                {
+                    statusMessage =
+                        $"Wrote {parsedDocument.Objects.Count} likely objects to {System.IO.Path.GetFileName(outputPath)} and validated round-trip count.";
+                }
             }
             catch (System.Exception ex)
             {
+                roundTripDocument = null;
                 statusMessage = $"Parse/write failed: {ex.Message}";
             }
         }

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -112,8 +112,21 @@ namespace Toontown.Editor
         {
             try
             {
-                IWorldDataDocumentReader reader = new ToontownWorldDataDocumentReader();
-                IWorldDataDocumentWriter writer = new ToontownWorldDataDocumentWriter();
+                // Prefer the active adapter when set to Toontown.
+                // Fallback keeps this window functional if flavor is not switched yet.
+                IWorldDataDocumentReader reader;
+                IWorldDataDocumentWriter writer;
+                if (WorldDataToolRouteResolver.GetActiveGameFlavor() == GameFlavor.Toontown)
+                {
+                    var adapter = WorldDataFormatAdapterRegistry.GetActiveAdapter();
+                    reader = adapter.Reader;
+                    writer = adapter.Writer;
+                }
+                else
+                {
+                    reader = new ToontownWorldDataDocumentReader();
+                    writer = new ToontownWorldDataDocumentWriter();
+                }
 
                 if (!reader.CanRead(sourcePath))
                 {
@@ -135,12 +148,12 @@ namespace Toontown.Editor
                 if (roundTripDocument.Objects.Count != parsedDocument.Objects.Count)
                 {
                     statusMessage =
-                        $"Wrote file but round-trip object count mismatch: in={parsedDocument.Objects.Count}, out={roundTripDocument.Objects.Count}.";
+                        $"Wrote file with {writer.FormatId}, but round-trip object count mismatch: in={parsedDocument.Objects.Count}, out={roundTripDocument.Objects.Count}.";
                 }
                 else
                 {
                     statusMessage =
-                        $"Wrote {parsedDocument.Objects.Count} likely objects to {System.IO.Path.GetFileName(outputPath)} and validated round-trip count.";
+                        $"Wrote {parsedDocument.Objects.Count} likely objects to {System.IO.Path.GetFileName(outputPath)} using {writer.FormatId} and validated round-trip count.";
                 }
             }
             catch (System.Exception ex)

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Toontown.Editor
+{
+    public sealed class ToontownWorldDataExporter : EditorWindow
+    {
+        [MenuItem("Toontown/World Data/Exporter")]
+        public static void ShowWindow()
+        {
+            GetWindow<ToontownWorldDataExporter>("Toontown Exporter");
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Toontown World Data Exporter", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(
+                "Scaffold ready. Export pipeline will be added once Toontown object/property mapping is defined.",
+                MessageType.Info);
+
+            if (GUILayout.Button("Open Migration Plan"))
+            {
+                Debug.Log("See docs/TOONTOWN_MIGRATION_PLAN.md for implementation phases.");
+            }
+        }
+    }
+}

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -75,6 +75,16 @@ namespace Toontown.Editor
             {
                 EditorGUILayout.LabelField("Last Parsed Document", parsedDocument.Name);
                 EditorGUILayout.LabelField("Likely Objects", parsedDocument.Objects.Count.ToString());
+                EditorGUILayout.LabelField("Warnings", parsedDocument.Warnings.Count.ToString());
+
+                if (parsedDocument.Warnings.Count > 0)
+                {
+                    EditorGUILayout.Space();
+                    for (int i = 0; i < parsedDocument.Warnings.Count; i++)
+                    {
+                        EditorGUILayout.HelpBox(parsedDocument.Warnings[i], MessageType.Warning);
+                    }
+                }
             }
 
             EditorGUILayout.Space();

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -1,10 +1,19 @@
 using UnityEditor;
 using UnityEngine;
+using Toolkit.Core;
+using Toolkit.Editor.WorldData;
+using Toolkit.Editor.WorldData.Adapters.Toontown;
+using Toolkit.Editor.WorldData.Contracts;
 
 namespace Toontown.Editor
 {
     public sealed class ToontownWorldDataExporter : EditorWindow
     {
+        private string sourcePath;
+        private string outputPath;
+        private string statusMessage = "Select source and output files.";
+        private WorldDataDocument parsedDocument;
+
         [MenuItem("Toontown/World Data/Exporter")]
         public static void ShowWindow()
         {
@@ -15,13 +24,95 @@ namespace Toontown.Editor
         {
             EditorGUILayout.LabelField("Toontown World Data Exporter", EditorStyles.boldLabel);
             EditorGUILayout.Space();
-            EditorGUILayout.HelpBox(
-                "Scaffold ready. Export pipeline will be added once Toontown object/property mapping is defined.",
-                MessageType.Info);
 
+            if (WorldDataToolRouteResolver.GetActiveGameFlavor() != GameFlavor.Toontown)
+            {
+                EditorGUILayout.HelpBox(
+                    "Active game flavor is not set to Toontown. Switch in Toolkit/Settings for consistent routing.",
+                    MessageType.Warning);
+            }
+
+            if (GUILayout.Button("Select Source .py File"))
+            {
+                string selected = EditorUtility.OpenFilePanel("Select Toontown Source", Application.dataPath, "py");
+                if (!string.IsNullOrEmpty(selected))
+                {
+                    sourcePath = selected;
+                    statusMessage = $"Selected source: {System.IO.Path.GetFileName(sourcePath)}";
+                }
+            }
+
+            if (GUILayout.Button("Select Output .py File"))
+            {
+                string selected = EditorUtility.SaveFilePanel(
+                    "Select Toontown Output",
+                    Application.dataPath,
+                    "toontown_export.py",
+                    "py");
+
+                if (!string.IsNullOrEmpty(selected))
+                {
+                    outputPath = selected;
+                    statusMessage = $"Selected output: {System.IO.Path.GetFileName(outputPath)}";
+                }
+            }
+
+            EditorGUILayout.LabelField("Source", string.IsNullOrWhiteSpace(sourcePath) ? "<none>" : sourcePath);
+            EditorGUILayout.LabelField("Output", string.IsNullOrWhiteSpace(outputPath) ? "<none>" : outputPath);
+            EditorGUILayout.Space();
+
+            EditorGUI.BeginDisabledGroup(string.IsNullOrWhiteSpace(sourcePath) || string.IsNullOrWhiteSpace(outputPath));
+            if (GUILayout.Button("Parse And Write"))
+            {
+                ParseAndWrite();
+            }
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(statusMessage, MessageType.Info);
+
+            if (parsedDocument != null)
+            {
+                EditorGUILayout.LabelField("Last Parsed Document", parsedDocument.Name);
+                EditorGUILayout.LabelField("Likely Objects", parsedDocument.Objects.Count.ToString());
+            }
+
+            EditorGUILayout.Space();
             if (GUILayout.Button("Open Migration Plan"))
             {
                 Debug.Log("See docs/TOONTOWN_MIGRATION_PLAN.md for implementation phases.");
+            }
+        }
+
+        private void ParseAndWrite()
+        {
+            try
+            {
+                IWorldDataDocumentReader reader = new ToontownWorldDataDocumentReader();
+                IWorldDataDocumentWriter writer = new ToontownWorldDataDocumentWriter();
+
+                if (!reader.CanRead(sourcePath))
+                {
+                    statusMessage = $"Reader '{reader.FormatId}' cannot parse source file.";
+                    parsedDocument = null;
+                    return;
+                }
+
+                if (!writer.CanWrite(outputPath))
+                {
+                    statusMessage = $"Writer '{writer.FormatId}' cannot write output file.";
+                    return;
+                }
+
+                parsedDocument = reader.ReadFromFile(sourcePath);
+                writer.WriteToFile(parsedDocument, outputPath);
+
+                statusMessage =
+                    $"Wrote {parsedDocument.Objects.Count} likely objects to {System.IO.Path.GetFileName(outputPath)}.";
+            }
+            catch (System.Exception ex)
+            {
+                statusMessage = $"Parse/write failed: {ex.Message}";
             }
         }
     }

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -43,6 +43,20 @@ namespace Toontown.Editor
                 }
             }
 
+            if (GUILayout.Button("Use Bundled Sample Source"))
+            {
+                if (!ToontownToolkitPaths.BundledSampleExists())
+                {
+                    statusMessage =
+                        $"Bundled sample not found at {ToontownToolkitPaths.BundledSampleRelativePath}.";
+                }
+                else
+                {
+                    sourcePath = ToontownToolkitPaths.BundledSampleFullPath;
+                    statusMessage = $"Selected bundled source: {System.IO.Path.GetFileName(sourcePath)}";
+                }
+            }
+
             if (GUILayout.Button("Select Output .py File"))
             {
                 string selected = EditorUtility.SaveFilePanel(
@@ -56,6 +70,13 @@ namespace Toontown.Editor
                     outputPath = selected;
                     statusMessage = $"Selected output: {System.IO.Path.GetFileName(outputPath)}";
                 }
+            }
+
+            if (GUILayout.Button("Use Suggested Output Path"))
+            {
+                ToontownToolkitPaths.EnsureSuggestedExportDirectoryExists();
+                outputPath = ToontownToolkitPaths.SuggestedExportFullPath;
+                statusMessage = $"Selected output: {System.IO.Path.GetFileName(outputPath)}";
             }
 
             EditorGUILayout.LabelField("Source", string.IsNullOrWhiteSpace(sourcePath) ? "<none>" : sourcePath);

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs
@@ -101,6 +101,11 @@ namespace Toontown.Editor
             {
                 Debug.Log("See docs/TOONTOWN_MIGRATION_PLAN.md for implementation phases.");
             }
+
+            if (GUILayout.Button("Open Type Map Config"))
+            {
+                EditorUtility.OpenWithDefaultApp(ToontownObjectTypeMapper.ConfigFullPath);
+            }
         }
 
         private void ParseAndWrite()

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Toontown.Editor
+{
+    public sealed class ToontownWorldDataImporter : EditorWindow
+    {
+        [MenuItem("Toontown/World Data/Importer")]
+        public static void ShowWindow()
+        {
+            GetWindow<ToontownWorldDataImporter>("Toontown Importer");
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Toontown World Data Importer", EditorStyles.boldLabel);
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(
+                "Scaffold ready. This window is intentionally minimal until Toontown format adapters are implemented.",
+                MessageType.Info);
+
+            if (GUILayout.Button("Open Migration Plan"))
+            {
+                Debug.Log("See docs/TOONTOWN_MIGRATION_PLAN.md for implementation phases.");
+            }
+        }
+    }
+}

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using Toolkit.Core;
@@ -112,6 +113,24 @@ namespace Toontown.Editor
 
             EditorGUILayout.LabelField("Objects with Model", withModel.ToString());
             EditorGUILayout.LabelField("Objects with Type", withType.ToString());
+            EditorGUILayout.Space();
+
+            var typeCounts = new System.Collections.Generic.Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+            foreach (var obj in document.Objects)
+            {
+                string t = obj.Properties.ContainsKey("Type") ? obj.Properties["Type"] : "<none>";
+                if (!typeCounts.ContainsKey(t)) typeCounts[t] = 0;
+                typeCounts[t]++;
+            }
+
+            EditorGUILayout.LabelField("Top Types", EditorStyles.boldLabel);
+            int shown = 0;
+            foreach (var kvp in typeCounts.OrderByDescending(x => x.Value))
+            {
+                EditorGUILayout.LabelField($"- {kvp.Key}: {kvp.Value}");
+                shown++;
+                if (shown >= 8) break;
+            }
             EditorGUILayout.Space();
 
             scroll = EditorGUILayout.BeginScrollView(scroll, GUILayout.Height(180));

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
@@ -1,10 +1,19 @@
 using UnityEditor;
 using UnityEngine;
+using Toolkit.Core;
+using Toolkit.Editor.WorldData;
+using Toolkit.Editor.WorldData.Adapters.Toontown;
+using Toolkit.Editor.WorldData.Contracts;
 
 namespace Toontown.Editor
 {
     public sealed class ToontownWorldDataImporter : EditorWindow
     {
+        private string sourcePath;
+        private string statusMessage = "No file selected.";
+        private Vector2 scroll;
+        private WorldDataDocument parsedDocument;
+
         [MenuItem("Toontown/World Data/Importer")]
         public static void ShowWindow()
         {
@@ -15,14 +24,105 @@ namespace Toontown.Editor
         {
             EditorGUILayout.LabelField("Toontown World Data Importer", EditorStyles.boldLabel);
             EditorGUILayout.Space();
-            EditorGUILayout.HelpBox(
-                "Scaffold ready. This window is intentionally minimal until Toontown format adapters are implemented.",
-                MessageType.Info);
 
+            if (WorldDataToolRouteResolver.GetActiveGameFlavor() != GameFlavor.Toontown)
+            {
+                EditorGUILayout.HelpBox(
+                    "Active game flavor is not set to Toontown. Switch in Toolkit/Settings for consistent routing.",
+                    MessageType.Warning);
+            }
+
+            if (GUILayout.Button("Select Source .py File"))
+            {
+                string selected = EditorUtility.OpenFilePanel("Select Toontown Source", Application.dataPath, "py");
+                if (!string.IsNullOrEmpty(selected))
+                {
+                    sourcePath = selected;
+                    statusMessage = $"Selected: {System.IO.Path.GetFileName(sourcePath)}";
+                }
+            }
+
+            EditorGUILayout.LabelField("File", string.IsNullOrEmpty(sourcePath) ? "<none>" : sourcePath);
+            EditorGUILayout.Space();
+
+            EditorGUI.BeginDisabledGroup(string.IsNullOrWhiteSpace(sourcePath));
+            if (GUILayout.Button("Parse Preview"))
+            {
+                ParseSelectedFile();
+            }
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(statusMessage, MessageType.Info);
+
+            if (parsedDocument != null)
+            {
+                DrawParsedSummary(parsedDocument);
+            }
+
+            EditorGUILayout.Space();
             if (GUILayout.Button("Open Migration Plan"))
             {
                 Debug.Log("See docs/TOONTOWN_MIGRATION_PLAN.md for implementation phases.");
             }
+        }
+
+        private void ParseSelectedFile()
+        {
+            try
+            {
+                // Prefer the active adapter when set to Toontown.
+                // Fallback to explicit Toontown reader so this window is still usable if flavor is not switched yet.
+                var reader = WorldDataToolRouteResolver.GetActiveGameFlavor() == GameFlavor.Toontown
+                    ? WorldDataFormatAdapterRegistry.GetActiveAdapter().Reader
+                    : new ToontownWorldDataDocumentReader();
+
+                if (!reader.CanRead(sourcePath))
+                {
+                    statusMessage = $"Reader '{reader.FormatId}' cannot parse this file type.";
+                    parsedDocument = null;
+                    return;
+                }
+
+                parsedDocument = reader.ReadFromFile(sourcePath);
+                statusMessage = $"Parsed {parsedDocument.Objects.Count} likely world objects via {reader.FormatId}.";
+            }
+            catch (System.Exception ex)
+            {
+                parsedDocument = null;
+                statusMessage = $"Parse failed: {ex.Message}";
+            }
+        }
+
+        private void DrawParsedSummary(WorldDataDocument document)
+        {
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField("Parsed Preview", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Document", document.Name);
+            EditorGUILayout.LabelField("Likely Objects", document.Objects.Count.ToString());
+
+            int withModel = 0;
+            int withType = 0;
+            foreach (var obj in document.Objects)
+            {
+                if (obj.Properties.ContainsKey("Model")) withModel++;
+                if (obj.Properties.ContainsKey("Type")) withType++;
+            }
+
+            EditorGUILayout.LabelField("Objects with Model", withModel.ToString());
+            EditorGUILayout.LabelField("Objects with Type", withType.ToString());
+            EditorGUILayout.Space();
+
+            scroll = EditorGUILayout.BeginScrollView(scroll, GUILayout.Height(180));
+            int previewCount = Mathf.Min(document.Objects.Count, 25);
+            for (int i = 0; i < previewCount; i++)
+            {
+                WorldDataObject obj = document.Objects[i];
+                string type = obj.Properties.ContainsKey("Type") ? obj.Properties["Type"] : "<none>";
+                EditorGUILayout.LabelField($"[{i + 1}] {obj.Id} (Type: {type})");
+            }
+            EditorGUILayout.EndScrollView();
+            EditorGUILayout.EndVertical();
         }
     }
 }

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
@@ -100,6 +100,7 @@ namespace Toontown.Editor
             EditorGUILayout.LabelField("Parsed Preview", EditorStyles.boldLabel);
             EditorGUILayout.LabelField("Document", document.Name);
             EditorGUILayout.LabelField("Likely Objects", document.Objects.Count.ToString());
+            EditorGUILayout.LabelField("Warnings", document.Warnings.Count.ToString());
 
             int withModel = 0;
             int withType = 0;
@@ -122,6 +123,17 @@ namespace Toontown.Editor
                 EditorGUILayout.LabelField($"[{i + 1}] {obj.Id} (Type: {type})");
             }
             EditorGUILayout.EndScrollView();
+
+            if (document.Warnings.Count > 0)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Warnings", EditorStyles.boldLabel);
+                for (int i = 0; i < document.Warnings.Count; i++)
+                {
+                    EditorGUILayout.HelpBox(document.Warnings[i], MessageType.Warning);
+                }
+            }
+
             EditorGUILayout.EndVertical();
         }
     }

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
@@ -66,6 +66,11 @@ namespace Toontown.Editor
             {
                 Debug.Log("See docs/TOONTOWN_MIGRATION_PLAN.md for implementation phases.");
             }
+
+            if (GUILayout.Button("Open Type Map Config"))
+            {
+                EditorUtility.OpenWithDefaultApp(ToontownObjectTypeMapper.ConfigFullPath);
+            }
         }
 
         private void ParseSelectedFile()

--- a/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
+++ b/Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs
@@ -43,6 +43,20 @@ namespace Toontown.Editor
                 }
             }
 
+            if (GUILayout.Button("Use Bundled Sample File"))
+            {
+                if (!ToontownToolkitPaths.BundledSampleExists())
+                {
+                    statusMessage =
+                        $"Bundled sample not found at {ToontownToolkitPaths.BundledSampleRelativePath}.";
+                }
+                else
+                {
+                    sourcePath = ToontownToolkitPaths.BundledSampleFullPath;
+                    statusMessage = $"Selected bundled sample: {System.IO.Path.GetFileName(sourcePath)}";
+                }
+            }
+
             EditorGUILayout.LabelField("File", string.IsNullOrEmpty(sourcePath) ? "<none>" : sourcePath);
             EditorGUILayout.Space();
 

--- a/Assets/Scripts/Toolkit/Core/GameFlavor.cs
+++ b/Assets/Scripts/Toolkit/Core/GameFlavor.cs
@@ -1,0 +1,8 @@
+namespace Toolkit.Core
+{
+    public enum GameFlavor
+    {
+        POTCO = 0,
+        Toontown = 1
+    }
+}

--- a/Assets/Scripts/Toolkit/Core/ToolkitProjectSettings.cs
+++ b/Assets/Scripts/Toolkit/Core/ToolkitProjectSettings.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace Toolkit.Core
+{
+    [CreateAssetMenu(fileName = "ToolkitProjectSettings", menuName = "Toolkit/Project Settings")]
+    public sealed class ToolkitProjectSettings : ScriptableObject
+    {
+        public GameFlavor activeGameFlavor = GameFlavor.POTCO;
+        public bool enableVerboseLogs;
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,15 @@ Use GitHub's private noreply email for local commits:
   - `feat: add Toontown sample validator CSV export`
   - `chore: add PR readiness run action`
 - Do not mix broad refactors with behavior changes in one commit.
+- Allowed commit types:
+  - `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`
+- Subject format:
+  - `type(scope): summary` or `type: summary`
+- Keep subject length at or below 72 characters when possible (warning-only).
 
 ## Required Checks Before Commit
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/primary-checks.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/commit-message-check.ps1 -BaseRef upstream/main`
 - Optional release-style pass:
   - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/manual-readiness.ps1 -BaseRef upstream/main`
 
@@ -34,6 +40,7 @@ Use GitHub's private noreply email for local commits:
 3. Complete `.github/pull_request_template.md`.
 4. Ensure Actions are green:
    - `Primary CI`
+   - `Commit Quality`
    - `PR Readiness`
 
 ## Beginner Steering

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+This repository is run with a human-led workflow and small, reviewable commits.
+
+## Quick Start
+1. Fork this repository in GitHub.
+2. Clone your fork locally.
+3. Add upstream:
+   - `git remote add upstream https://github.com/JackScurvy/POTCO-Unity-Toolkit.git`
+4. Create a feature branch:
+   - `git checkout -b codex/<short-feature-name>`
+
+## Git Identity (GitHub private email)
+Use GitHub's private noreply email for local commits:
+- `git config user.name "sirwranwrap"`
+- `git config user.email "sirwranwrap@users.noreply.github.com"`
+
+## Commit Rules
+- One logical objective per commit.
+- Use imperative commit messages:
+  - `feat: add Toontown sample validator CSV export`
+  - `chore: add PR readiness run action`
+- Do not mix broad refactors with behavior changes in one commit.
+
+## Required Checks Before Commit
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/primary-checks.ps1`
+- Optional release-style pass:
+  - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/manual-readiness.ps1 -BaseRef upstream/main`
+
+## Pull Request Steps
+1. Push your branch:
+   - `git push -u origin codex/<short-feature-name>`
+2. Open a pull request to `main`.
+3. Complete `.github/pull_request_template.md`.
+4. Ensure Actions are green:
+   - `Primary CI`
+   - `PR Readiness`
+
+## Beginner Steering
+Common mistakes to avoid:
+- editing many systems before a first commit
+- skipping primary checks
+- changing POTCO behavior while intending Toontown-only scaffolding
+
+If you are unsure, update `docs/TOONTOWN_MIGRATION_PLAN.md` first, then implement in small steps.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Pirates of the Caribbean Online - Unity Toolkit
+# POTCO + Toontown Unity Toolkit
 
-> A Unity Editor toolkit for working with Panda3D - POTCO game assets, world data, and level creation.
+> A Unity Editor toolkit for Panda3D-style game assets and world data workflows, with POTCO support and an active Toontown migration path.
 ---
 <p align="center">
 Got any questions?
@@ -19,9 +19,9 @@ Got any questions?
 
 ## ✨ What is this?
 
-This toolkit brings **Pirates of the Caribbean Online** into Unity, allowing you to import game worlds, export custom content, build new experiences, and create levels using authentic POTCO assets. This was created using the help of AI to expedite the process. So please excuse if the code is 🔥🗑️ but it works! 😎
+This toolkit brings **Pirates of the Caribbean Online** workflows into Unity and now includes an active **Toontown toolchain migration path**. You can import world data, export custom content, and build scene tooling with a shared adapter architecture.
 
-The whole point of this is to bring out the creativity within our community, creating custom worlds and being able to share them or even potentially create little mini games using the POTCO assets within Unity. One thing that our community lacks from our sister community Toontown is the amount of user generated content. We need more of that!
+The goal is to support community-made worlds and tooling while keeping migration work practical and incremental. POTCO tools remain available, and Toontown tools can be launched now through the quick-start flow.
 
 ## 🚀 Features
 
@@ -31,6 +31,13 @@ The whole point of this is to bring out the creativity within our community, cre
 ⛏️ **Procedural Cave Generator** - Create interconnected cave systems with presets  
 🎨 **Advanced EGG File Importer** - Import Panda3D .egg models              
 🖼️ **Native .RGB Importer** - Supports .rgb alpha transparency 
+
+### Toontown Migration Tooling (Current)
+- ✅ `Toontown/Quick Start` launcher
+- ✅ Bundled sample world for first-run validation
+- ✅ Toontown importer/exporter parse + round-trip scaffold
+- ✅ `Toontown/Validation/Run Sample Smoke Test`
+- ✅ CSV validation report export for mapping/tuning evidence
 
 ### Level Creation & Management
 🏗️ **Level Editor (Prop Browser)** - Visual asset browser and placement tool  
@@ -194,9 +201,9 @@ This project is designed for **educational and research purposes**:
 
 ---
 
-## 🏴‍☠️ Set Sail!
+## 🏴‍☠️ Build and Iterate!
 
-Transform Unity into your personal POTCO playground and level creation environment. With the new Level Editor, asset browser, and enhanced import systems, creating custom POTCO content has never been easier!
+Transform Unity into a practical game-world toolkit for POTCO and the ongoing Toontown migration flow. Start with the quick-start path, run smoke checks, and iterate in small validated steps.
 
 **Create, explore, and share your pirate adventures!** ⚓
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Open the project in Unity 6000.1.11f1, then access tools via:
 - Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Engineering workflow: [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
 - Toontown migration plan: [`docs/TOONTOWN_MIGRATION_PLAN.md`](docs/TOONTOWN_MIGRATION_PLAN.md)
+- Toontown quick start (first runnable flow): [`docs/TOONTOWN_QUICKSTART.md`](docs/TOONTOWN_QUICKSTART.md)
 - Required baseline check before commit:
   - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/primary-checks.ps1`
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ The whole point of this is to bring out the creativity within our community, cre
 Open the project in Unity 6000.1.11f1, then access tools via:
 **Unity Menu Bar → POTCO → [Choose Tool]**
 
+## 🧭 Contribution Workflow
+- Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Engineering workflow: [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
+- Toontown migration plan: [`docs/TOONTOWN_MIGRATION_PLAN.md`](docs/TOONTOWN_MIGRATION_PLAN.md)
+- Required baseline check before commit:
+  - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/primary-checks.ps1`
+
 ---
 
 ## 🎮 Tools Overview

--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ Visual asset management and level creation tool:
 5. Assets are automatically categorized and ready for export
 6. Select "🎯Surface" for any placed models either from importing or dragging out to contain collisions to be able to easily drag and drop props on top seemlessly will cause the world importer to take longer
 
+### Toontown First Launch (Current Migration Flow)
+1. Open `Toontown → Quick Start`
+2. Click `Switch Active Game Flavor to Toontown`
+3. Open importer/exporter from quick-start buttons
+4. Use bundled sample actions to run parse + export loop
+5. Run `Toontown → Validation → Run Sample Smoke Test`
+
 
 ### Generate a Cave
 1. Open `POTCO → Procedural Cave Generator`  

--- a/docs/BEGINNER_REMINDERS.md
+++ b/docs/BEGINNER_REMINDERS.md
@@ -1,0 +1,22 @@
+# Beginner Reminders
+
+## If You Feel Lost
+- That is normal. Use the migration plan phase by phase.
+- Change one thing at a time and commit often.
+- Ask "what problem does this change solve" before editing files.
+
+## Common Mistakes To Avoid
+- Changing multiple systems in one commit.
+- Renaming files and changing logic in the same commit.
+- Skipping quick checks before committing.
+- Editing POTCO code when you meant to add Toontown scaffolding.
+
+## Before Every Commit
+- Confirm commit touches only one objective.
+- Confirm file names match intent.
+- Confirm no placeholder code is left ambiguous.
+- Write a commit message that explains the user-visible impact.
+
+## When Unsure
+- Stop and make a small doc note in `docs/TOONTOWN_MIGRATION_PLAN.md`.
+- Then ask for review before proceeding to the next phase.

--- a/docs/BEGINNER_REMINDERS.md
+++ b/docs/BEGINNER_REMINDERS.md
@@ -4,6 +4,7 @@
 - That is normal. Use the migration plan phase by phase.
 - Change one thing at a time and commit often.
 - Ask "what problem does this change solve" before editing files.
+- Use `Toontown/Quick Start` to run bundled sample parse/export before editing parser logic.
 
 ## Common Mistakes To Avoid
 - Changing multiple systems in one commit.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,31 @@
+# Release Checklist
+
+Use this checklist before publishing major Toontown migration milestones.
+
+## 1. Branch and Scope
+- [ ] Branch is focused on one milestone objective.
+- [ ] Commit history is clear and logically grouped.
+- [ ] No unrelated files are included.
+
+## 2. Local Validation
+- [ ] Run primary checks:
+  - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/primary-checks.ps1`
+- [ ] Run manual readiness:
+  - `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/manual-readiness.ps1 -BaseRef upstream/main`
+- [ ] Confirm Unity tool windows open and function for changed paths.
+
+## 3. Documentation
+- [ ] `docs/TOONTOWN_MIGRATION_PLAN.md` updated with behavior changes.
+- [ ] `docs/BEGINNER_REMINDERS.md` updated when new pitfalls are found.
+- [ ] `README.md` links are still accurate for contributor flow.
+
+## 4. Pull Request Quality
+- [ ] Pull request template is completed.
+- [ ] `Primary CI` is green.
+- [ ] `PR Readiness` is green.
+- [ ] Reviewer can explain the change intent in one sentence.
+
+## 5. Post-Merge Follow-Up
+- [ ] Confirm `Weekly Health` run remains green after merge.
+- [ ] Capture next small milestone in migration plan.
+- [ ] Document any temporary compromises and cleanup plan.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -23,6 +23,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added a shared world-data routing layer under `Assets/Editor/Toolkit/WorldData`.
 - Added route interfaces and game-specific route providers (`POTCO`, `Toontown`).
 - Added `Toolkit/World Data/Router` window to open the active importer/exporter safely.
+- Added tool-launcher adapters so router calls go through shared abstractions instead of direct UI menu calls.
 - Added shared world-data contracts (`IWorldDataDocumentReader`, `IWorldDataDocumentWriter`, `IWorldDataFormatAdapter`).
 - Added POTCO and Toontown format adapter scaffolds behind a shared registry.
 - POTCO importer/exporter code paths are unchanged.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -51,6 +51,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Hardened reader scope handling so candidate objects are only collected from `Objects` dictionary regions (reduces metadata false positives).
 - Added multi-line continuation parsing for bracket/parenthesis property values to improve extraction from wrapped world-data fields.
 - Added bundled sample world and one-click quick-start actions across importer/exporter/validator for first-run usability.
+- Added bundled sample sanity guard in primary checks to keep quick-start inputs stable across future commits.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -53,6 +53,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added bundled sample world and one-click quick-start actions across importer/exporter/validator for first-run usability.
 - Added bundled sample sanity guard in primary checks to keep quick-start inputs stable across future commits.
 - Added `Toontown/Validation/Run Sample Smoke Test` to run parse/export/re-parse verification in one menu action.
+- Updated smoke test runner to be batch-safe (no modal dialog in headless execution).
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -50,6 +50,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added CSV report export from validator for tuning evidence and iterative mapping comparisons.
 - Hardened reader scope handling so candidate objects are only collected from `Objects` dictionary regions (reduces metadata false positives).
 - Added multi-line continuation parsing for bracket/parenthesis property values to improve extraction from wrapped world-data fields.
+- Added bundled sample world and one-click quick-start actions across importer/exporter/validator for first-run usability.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -46,6 +46,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added quick access buttons in Toontown importer/exporter to open the type-map config.
 - Added Toontown property normalization and preferred write-order rules for cleaner exports.
 - Routed Toontown exporter parse/write operations through shared adapter contracts when Toontown flavor is active.
+- Added `Toontown/Validation/Sample Validator` for parse quality benchmarking (unknown type ratio, duplicates, warnings).
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -42,6 +42,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Wired Toontown exporter window for parse-and-write round-trip scaffolding.
 - Added warning surfacing in Toontown importer/exporter for low-confidence parse scenarios.
 - Implemented Toontown object type mapping source via `Assets/Editor/Toontown/Config/ObjectTypeMap.json`.
+- Added exporter round-trip count validation (re-parse exported output and compare likely object counts).
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -40,6 +40,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Wired Toontown importer window to parse and preview object summaries through shared contracts.
 - Implemented initial Toontown writer pass for `WorldDataDocument` output (`objectStruct` + nested `Objects`).
 - Wired Toontown exporter window for parse-and-write round-trip scaffolding.
+- Added warning surfacing in Toontown importer/exporter for low-confidence parse scenarios.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -19,6 +19,12 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Move POTCO-specific logic behind POTCO adapters.
 - Define interfaces for world object parsing and serialization.
 
+### Phase 2 Progress
+- Added a shared world-data routing layer under `Assets/Editor/Toolkit/WorldData`.
+- Added route interfaces and game-specific route providers (`POTCO`, `Toontown`).
+- Added `Toolkit/World Data/Router` window to open the active importer/exporter safely.
+- POTCO importer/exporter code paths are unchanged.
+
 ## Phase 3 - Toontown Adapters
 - Implement Toontown world reader.
 - Implement Toontown world writer.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -52,6 +52,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added multi-line continuation parsing for bracket/parenthesis property values to improve extraction from wrapped world-data fields.
 - Added bundled sample world and one-click quick-start actions across importer/exporter/validator for first-run usability.
 - Added bundled sample sanity guard in primary checks to keep quick-start inputs stable across future commits.
+- Added `Toontown/Validation/Run Sample Smoke Test` to run parse/export/re-parse verification in one menu action.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -48,6 +48,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Routed Toontown exporter parse/write operations through shared adapter contracts when Toontown flavor is active.
 - Added `Toontown/Validation/Sample Validator` for parse quality benchmarking (unknown type ratio, duplicates, warnings).
 - Added CSV report export from validator for tuning evidence and iterative mapping comparisons.
+- Hardened reader scope handling so candidate objects are only collected from `Objects` dictionary regions (reduces metadata false positives).
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -45,6 +45,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added exporter round-trip count validation (re-parse exported output and compare likely object counts).
 - Added quick access buttons in Toontown importer/exporter to open the type-map config.
 - Added Toontown property normalization and preferred write-order rules for cleaner exports.
+- Routed Toontown exporter parse/write operations through shared adapter contracts when Toontown flavor is active.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -24,6 +24,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added route interfaces and game-specific route providers (`POTCO`, `Toontown`).
 - Added `Toolkit/World Data/Router` window to open the active importer/exporter safely.
 - Added tool-launcher adapters so router calls go through shared abstractions instead of direct UI menu calls.
+- Added shared menu entry points (`Toolkit/World Data/Open Importer`, `Open Exporter`) that delegate to the active launcher.
 - Added shared world-data contracts (`IWorldDataDocumentReader`, `IWorldDataDocumentWriter`, `IWorldDataFormatAdapter`).
 - Added POTCO and Toontown format adapter scaffolds behind a shared registry.
 - POTCO importer/exporter code paths are unchanged.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -49,6 +49,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added `Toontown/Validation/Sample Validator` for parse quality benchmarking (unknown type ratio, duplicates, warnings).
 - Added CSV report export from validator for tuning evidence and iterative mapping comparisons.
 - Hardened reader scope handling so candidate objects are only collected from `Objects` dictionary regions (reduces metadata false positives).
+- Added multi-line continuation parsing for bracket/parenthesis property values to improve extraction from wrapped world-data fields.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -41,6 +41,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Implemented initial Toontown writer pass for `WorldDataDocument` output (`objectStruct` + nested `Objects`).
 - Wired Toontown exporter window for parse-and-write round-trip scaffolding.
 - Added warning surfacing in Toontown importer/exporter for low-confidence parse scenarios.
+- Implemented Toontown object type mapping source via `Assets/Editor/Toontown/Config/ObjectTypeMap.json`.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -35,6 +35,10 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Implement Toontown object type mapping source.
 - Implement Toontown-specific property handlers.
 
+### Phase 3 Progress
+- Implemented initial Toontown reader pass for `.py` dictionary-style world data (best-effort object extraction).
+- Wired Toontown importer window to parse and preview object summaries through shared contracts.
+
 ## Phase 4 - Validation
 - Import baseline sample world.
 - Export round-trip sample and verify structure.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -1,0 +1,36 @@
+# Toontown Port Plan
+
+## Goal
+Port reusable toolkit infrastructure from POTCO-specific workflows to a game-flavor architecture that can support Toontown Online data pipelines.
+
+## Operator Notes
+- Keep POTCO behavior stable while Toontown support is introduced.
+- Prefer additive scaffolding before refactors.
+- If uncertain, document the assumption first, then implement.
+
+## Phase 1 - Foundation
+- Add game-flavor configuration (`POTCO`, `Toontown`).
+- Add a single settings surface in Unity editor.
+- Add Toontown importer/exporter scaffolding windows.
+- Keep existing POTCO tools intact.
+
+## Phase 2 - Shared Core Extraction
+- Extract generic parsing, asset lookup, and coordinate helpers into shared utilities.
+- Move POTCO-specific logic behind POTCO adapters.
+- Define interfaces for world object parsing and serialization.
+
+## Phase 3 - Toontown Adapters
+- Implement Toontown world reader.
+- Implement Toontown world writer.
+- Implement Toontown object type mapping source.
+- Implement Toontown-specific property handlers.
+
+## Phase 4 - Validation
+- Import baseline sample world.
+- Export round-trip sample and verify structure.
+- Add migration notes and troubleshooting docs.
+
+## Non-Goals (Current Phase)
+- Full gameplay parity.
+- Character system parity.
+- Replacing POTCO runtime systems.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -44,6 +44,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Implemented Toontown object type mapping source via `Assets/Editor/Toontown/Config/ObjectTypeMap.json`.
 - Added exporter round-trip count validation (re-parse exported output and compare likely object counts).
 - Added quick access buttons in Toontown importer/exporter to open the type-map config.
+- Added Toontown property normalization and preferred write-order rules for cleaner exports.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -47,6 +47,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added Toontown property normalization and preferred write-order rules for cleaner exports.
 - Routed Toontown exporter parse/write operations through shared adapter contracts when Toontown flavor is active.
 - Added `Toontown/Validation/Sample Validator` for parse quality benchmarking (unknown type ratio, duplicates, warnings).
+- Added CSV report export from validator for tuning evidence and iterative mapping comparisons.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -43,6 +43,7 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added warning surfacing in Toontown importer/exporter for low-confidence parse scenarios.
 - Implemented Toontown object type mapping source via `Assets/Editor/Toontown/Config/ObjectTypeMap.json`.
 - Added exporter round-trip count validation (re-parse exported output and compare likely object counts).
+- Added quick access buttons in Toontown importer/exporter to open the type-map config.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -38,6 +38,8 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 ### Phase 3 Progress
 - Implemented initial Toontown reader pass for `.py` dictionary-style world data (best-effort object extraction).
 - Wired Toontown importer window to parse and preview object summaries through shared contracts.
+- Implemented initial Toontown writer pass for `WorldDataDocument` output (`objectStruct` + nested `Objects`).
+- Wired Toontown exporter window for parse-and-write round-trip scaffolding.
 
 ## Phase 4 - Validation
 - Import baseline sample world.

--- a/docs/TOONTOWN_MIGRATION_PLAN.md
+++ b/docs/TOONTOWN_MIGRATION_PLAN.md
@@ -23,6 +23,8 @@ Port reusable toolkit infrastructure from POTCO-specific workflows to a game-fla
 - Added a shared world-data routing layer under `Assets/Editor/Toolkit/WorldData`.
 - Added route interfaces and game-specific route providers (`POTCO`, `Toontown`).
 - Added `Toolkit/World Data/Router` window to open the active importer/exporter safely.
+- Added shared world-data contracts (`IWorldDataDocumentReader`, `IWorldDataDocumentWriter`, `IWorldDataFormatAdapter`).
+- Added POTCO and Toontown format adapter scaffolds behind a shared registry.
 - POTCO importer/exporter code paths are unchanged.
 
 ## Phase 3 - Toontown Adapters

--- a/docs/TOONTOWN_QUICKSTART.md
+++ b/docs/TOONTOWN_QUICKSTART.md
@@ -29,6 +29,10 @@ This is the fastest way to launch and use the Toontown tools in this repository.
 2. Click `Validate Bundled Sample`.
 3. Optionally click `Export CSV Report`.
 
+## 7. Run One-Click Smoke Test
+- Menu: `Toontown/Validation/Run Sample Smoke Test`
+- This runs parse -> export -> re-parse on bundled sample and prints a report to the Unity console.
+
 ## Common Pitfalls
 - If importer/exporter warns about active game flavor, set `Toolkit/Settings` to `Toontown`.
 - If parse count is zero, verify the source file has an `objectStruct['Objects']` dictionary.

--- a/docs/TOONTOWN_QUICKSTART.md
+++ b/docs/TOONTOWN_QUICKSTART.md
@@ -1,0 +1,35 @@
+# Toontown Quick Start
+
+This is the fastest way to launch and use the Toontown tools in this repository.
+
+## 1. Open Unity Project
+- Open the repo in Unity (`6000.1.11f1` recommended in README).
+
+## 2. Open Quick Start Window
+- Menu: `Toontown/Quick Start`
+
+## 3. Set Game Flavor
+- Click `Switch Active Game Flavor to Toontown`.
+
+## 4. Parse Sample Data
+1. Open `Toontown Importer` from quick start or menu `Toontown/World Data/Importer`.
+2. Click `Use Bundled Sample File`.
+3. Click `Parse Preview`.
+4. Confirm object count and warnings are shown.
+
+## 5. Export Sample Data
+1. Open `Toontown Exporter` from quick start or menu `Toontown/World Data/Exporter`.
+2. Click `Use Bundled Sample Source`.
+3. Click `Use Suggested Output Path`.
+4. Click `Parse And Write`.
+5. Confirm round-trip validation appears.
+
+## 6. Validate Parsing Quality
+1. Open `Toontown/Validation/Sample Validator`.
+2. Click `Validate Bundled Sample`.
+3. Optionally click `Export CSV Report`.
+
+## Common Pitfalls
+- If importer/exporter warns about active game flavor, set `Toolkit/Settings` to `Toontown`.
+- If parse count is zero, verify the source file has an `objectStruct['Objects']` dictionary.
+- Keep edits scoped and run `scripts/primary-checks.ps1` before committing.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -26,6 +26,7 @@
   - `Primary CI` for push and branch quality gates.
   - `PR Readiness` for pull-request base diff sanity and release-style checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
+  - `Weekly Health` for scheduled baseline checks on the default branch.
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
 - Primary checks validate Toontown type-map config JSON (`Assets/Editor/Toontown/Config/ObjectTypeMap.json`).
 - For Toontown tuning work, use `Toontown/Validation/Sample Validator` before changing type-map rules.
@@ -36,6 +37,7 @@
 | `Primary CI` | Push, pull request, manual dispatch | Required docs, merge-conflict markers, Toontown adapter guardrails, type-map JSON validity |
 | `PR Readiness` | Pull request, manual dispatch | Primary checks plus branch visibility, recent commit trail, and diff summary against PR base |
 | `Manual Readiness` | Manual dispatch | Operator-controlled readiness pass against a chosen base reference |
+| `Weekly Health` | Weekly schedule, manual dispatch | Recurring baseline `primary-checks` run for drift detection |
 
 ## Quality Gates
 - No dead code in committed changes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -27,6 +27,7 @@
   - `Commit Quality` for commit subject format and readability checks.
   - `PR Readiness` for pull-request base diff sanity and release-style checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
+  - `Toontown Smoke Gate` for Toontown-focused pull requests and manual smoke runs.
   - `Weekly Health` for scheduled baseline checks on the default branch.
   - `Sun Action` for Sunday scheduled baseline checks (with manual dispatch support).
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
@@ -41,6 +42,7 @@
 | `Commit Quality` | Push, pull request, manual dispatch | Commit subject style (`type(scope): summary`) with a soft warning for subjects over 72 chars |
 | `PR Readiness` | Pull request, manual dispatch | Primary checks plus branch visibility, recent commit trail, and diff summary against PR base |
 | `Manual Readiness` | Manual dispatch | Operator-controlled readiness pass against a chosen base reference |
+| `Toontown Smoke Gate` | Pull request (Toontown paths), manual dispatch | Toontown quick-start safety checks (`primary-checks` + bundled sample sanity) |
 | `Weekly Health` | Weekly schedule, manual dispatch | Recurring baseline `primary-checks` run for drift detection |
 | `Sun Action` | Weekly Sunday schedule, manual dispatch | Weekend baseline `primary-checks` run for fast health visibility |
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -28,6 +28,7 @@
   - `PR Readiness` for pull-request base diff sanity and release-style checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
   - `Weekly Health` for scheduled baseline checks on the default branch.
+  - `Sun Action` for Sunday scheduled baseline checks (with manual dispatch support).
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
 - Primary checks validate Toontown type-map config JSON (`Assets/Editor/Toontown/Config/ObjectTypeMap.json`).
 - Primary checks validate Toontown bundled sample sanity (`scripts/toontown-sample-sanity.ps1`).
@@ -41,6 +42,7 @@
 | `PR Readiness` | Pull request, manual dispatch | Primary checks plus branch visibility, recent commit trail, and diff summary against PR base |
 | `Manual Readiness` | Manual dispatch | Operator-controlled readiness pass against a chosen base reference |
 | `Weekly Health` | Weekly schedule, manual dispatch | Recurring baseline `primary-checks` run for drift detection |
+| `Sun Action` | Weekly Sunday schedule, manual dispatch | Weekend baseline `primary-checks` run for fast health visibility |
 
 ## Quality Gates
 - No dead code in committed changes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -27,6 +27,7 @@
   - `Manual Readiness` for operator-triggered release sanity checks.
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
 - Primary checks validate Toontown type-map config JSON (`Assets/Editor/Toontown/Config/ObjectTypeMap.json`).
+- For Toontown tuning work, use `Toontown/Validation/Sample Validator` before changing type-map rules.
 
 ## Quality Gates
 - No dead code in committed changes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -25,6 +25,7 @@
 - CI mirrors:
   - `Primary CI` for push/PR/default checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
+- Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
 
 ## Quality Gates
 - No dead code in committed changes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,40 @@
+# Engineering Workflow
+
+## Human-Led Authorship Standard
+- You make final decisions on scope and direction.
+- Every commit message is written as an intentional engineering decision.
+- Major changes include a short note in docs explaining why the change exists.
+
+## Branching
+- Use feature branches with prefix `codex/`.
+- Keep one purpose per branch.
+- Avoid mixing refactors and features in the same commit.
+
+## Commit Standards
+- Use clear commit subjects in imperative mood.
+- Keep commits scoped to one logical unit.
+- Commit order:
+  1. docs/chore
+  2. scaffolding
+  3. behavior changes
+  4. cleanup
+
+## Quality Gates
+- No dead code in committed changes.
+- Keep all new files and symbols named by domain intent.
+- Keep editor-only code under `Assets/Editor`.
+- Keep runtime code under `Assets/Scripts`.
+- Run quick grep checks before committing:
+  - no accidental TODO placeholders without context
+  - no cross-domain hardcoding in shared layers
+
+## Steering Checkpoints
+- Checkpoint A (before coding): confirm exact objective in one sentence.
+- Checkpoint B (before commit): confirm only one logical unit changed.
+- Checkpoint C (after commit): confirm next action is clear and small.
+
+## Review Checklist
+- Is change scoped and reversible?
+- Is naming clear to another engineer?
+- Is behavior change documented?
+- Is there an obvious next step for the following commit?

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -58,3 +58,6 @@
 - Is naming clear to another engineer?
 - Is behavior change documented?
 - Is there an obvious next step for the following commit?
+
+## Release Gate
+- Use `docs/RELEASE_CHECKLIST.md` before milestone merges.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -23,11 +23,19 @@
 - Primary (recommended): run `scripts/primary-checks.ps1`.
 - Manual readiness bundle: run `scripts/manual-readiness.ps1`.
 - CI mirrors:
-  - `Primary CI` for push/PR/default checks.
+  - `Primary CI` for push and branch quality gates.
+  - `PR Readiness` for pull-request base diff sanity and release-style checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
 - Primary checks validate Toontown type-map config JSON (`Assets/Editor/Toontown/Config/ObjectTypeMap.json`).
 - For Toontown tuning work, use `Toontown/Validation/Sample Validator` before changing type-map rules.
+
+### Action Quick Reference
+| Action | Trigger | What it validates |
+| --- | --- | --- |
+| `Primary CI` | Push, pull request, manual dispatch | Required docs, merge-conflict markers, Toontown adapter guardrails, type-map JSON validity |
+| `PR Readiness` | Pull request, manual dispatch | Primary checks plus branch visibility, recent commit trail, and diff summary against PR base |
+| `Manual Readiness` | Manual dispatch | Operator-controlled readiness pass against a chosen base reference |
 
 ## Quality Gates
 - No dead code in committed changes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -24,6 +24,7 @@
 - Manual readiness bundle: run `scripts/manual-readiness.ps1`.
 - CI mirrors:
   - `Primary CI` for push and branch quality gates.
+  - `Commit Quality` for commit subject format and readability checks.
   - `PR Readiness` for pull-request base diff sanity and release-style checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
   - `Weekly Health` for scheduled baseline checks on the default branch.
@@ -35,6 +36,7 @@
 | Action | Trigger | What it validates |
 | --- | --- | --- |
 | `Primary CI` | Push, pull request, manual dispatch | Required docs, merge-conflict markers, Toontown adapter guardrails, type-map JSON validity |
+| `Commit Quality` | Push, pull request, manual dispatch | Commit subject style (`type(scope): summary`) with a soft warning for subjects over 72 chars |
 | `PR Readiness` | Pull request, manual dispatch | Primary checks plus branch visibility, recent commit trail, and diff summary against PR base |
 | `Manual Readiness` | Manual dispatch | Operator-controlled readiness pass against a chosen base reference |
 | `Weekly Health` | Weekly schedule, manual dispatch | Recurring baseline `primary-checks` run for drift detection |

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -26,6 +26,7 @@
   - `Primary CI` for push/PR/default checks.
   - `Manual Readiness` for operator-triggered release sanity checks.
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
+- Primary checks validate Toontown type-map config JSON (`Assets/Editor/Toontown/Config/ObjectTypeMap.json`).
 
 ## Quality Gates
 - No dead code in committed changes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -30,6 +30,7 @@
   - `Weekly Health` for scheduled baseline checks on the default branch.
 - Primary checks include a guard that Toontown reader/writer are not reverted to stub-only implementations.
 - Primary checks validate Toontown type-map config JSON (`Assets/Editor/Toontown/Config/ObjectTypeMap.json`).
+- Primary checks validate Toontown bundled sample sanity (`scripts/toontown-sample-sanity.ps1`).
 - For Toontown tuning work, use `Toontown/Validation/Sample Validator` before changing type-map rules.
 
 ### Action Quick Reference

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -19,6 +19,13 @@
   3. behavior changes
   4. cleanup
 
+## Run Actions
+- Primary (recommended): run `scripts/primary-checks.ps1`.
+- Manual readiness bundle: run `scripts/manual-readiness.ps1`.
+- CI mirrors:
+  - `Primary CI` for push/PR/default checks.
+  - `Manual Readiness` for operator-triggered release sanity checks.
+
 ## Quality Gates
 - No dead code in committed changes.
 - Keep all new files and symbols named by domain intent.

--- a/scripts/checks.ps1
+++ b/scripts/checks.ps1
@@ -1,0 +1,37 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host '=== Project Checks ===' -ForegroundColor Cyan
+
+# 1) Ensure required docs exist
+$required = @(
+  'AGENTS.md',
+  'docs/WORKFLOW.md',
+  'docs/TOONTOWN_MIGRATION_PLAN.md',
+  'docs/BEGINNER_REMINDERS.md'
+)
+
+foreach ($path in $required) {
+  if (-not (Test-Path $path)) {
+    throw "Missing required file: $path"
+  }
+}
+Write-Host 'Required docs: OK' -ForegroundColor Green
+
+# 2) Ensure no merge conflict markers in tracked files
+# Match only true conflict marker lines, not divider comments with equals.
+$conflicts = git grep -n -E "^(<<<<<<< .+|=======|>>>>>>> .+)$" -- . ':!*.png' ':!*.jpg' ':!*.jpeg' ':!*.meta' 2>$null
+if ($LASTEXITCODE -eq 0 -and $conflicts) {
+  Write-Host $conflicts
+  throw 'Merge conflict markers found.'
+}
+Write-Host 'Conflict markers: OK' -ForegroundColor Green
+
+# 3) Show short git state for operator awareness
+$branch = git branch --show-current
+Write-Host ("Current branch: {0}" -f $branch) -ForegroundColor Yellow
+
+git status --short
+
+Write-Host 'All checks passed.' -ForegroundColor Green

--- a/scripts/checks.ps1
+++ b/scripts/checks.ps1
@@ -9,7 +9,8 @@ $required = @(
   'AGENTS.md',
   'docs/WORKFLOW.md',
   'docs/TOONTOWN_MIGRATION_PLAN.md',
-  'docs/BEGINNER_REMINDERS.md'
+  'docs/BEGINNER_REMINDERS.md',
+  'docs/TOONTOWN_QUICKSTART.md'
 )
 
 foreach ($path in $required) {

--- a/scripts/commit-message-check.ps1
+++ b/scripts/commit-message-check.ps1
@@ -1,0 +1,52 @@
+param(
+  [string]$BaseRef = "origin/main"
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host '=== Commit Message Check ===' -ForegroundColor Cyan
+Write-Host ("Base reference: {0}" -f $BaseRef) -ForegroundColor Yellow
+
+$pattern = '^(feat|fix|chore|docs|refactor|test|ci)(\([a-z0-9_\/-]+\))?: [A-Za-z0-9].+'
+
+git rev-parse --verify $BaseRef *> $null
+if ($LASTEXITCODE -ne 0) {
+  throw "Base ref not found locally: $BaseRef"
+}
+
+$subjects = git log --format=%s "$BaseRef..HEAD"
+if (-not $subjects) {
+  Write-Host 'No commits found in range; skipping.' -ForegroundColor Yellow
+  exit 0
+}
+
+$invalid = New-Object System.Collections.Generic.List[string]
+$warnings = New-Object System.Collections.Generic.List[string]
+
+foreach ($subject in $subjects) {
+  if ($subject.Length -gt 72) {
+    $warnings.Add("Subject longer than 72 chars (recommended max): $subject")
+  }
+
+  if ($subject -notmatch $pattern) {
+    $invalid.Add("Subject does not match required pattern: $subject")
+  }
+}
+
+if ($invalid.Count -gt 0) {
+  Write-Host 'Invalid commit subjects found:' -ForegroundColor Red
+  foreach ($line in $invalid) {
+    Write-Host ("- {0}" -f $line) -ForegroundColor Red
+  }
+
+  throw "Commit message check failed. Use: type(scope): summary"
+}
+
+if ($warnings.Count -gt 0) {
+  Write-Host 'Commit message warnings:' -ForegroundColor Yellow
+  foreach ($line in $warnings) {
+    Write-Host ("- {0}" -f $line) -ForegroundColor Yellow
+  }
+}
+
+Write-Host 'Commit message check: OK' -ForegroundColor Green

--- a/scripts/manual-readiness.ps1
+++ b/scripts/manual-readiness.ps1
@@ -1,0 +1,32 @@
+param(
+  [string]$BaseRef = "upstream/main"
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host '=== Manual Readiness ===' -ForegroundColor Cyan
+Write-Host ("Base reference: {0}" -f $BaseRef) -ForegroundColor Yellow
+
+# 1) Run primary checks.
+& "$PSScriptRoot/primary-checks.ps1"
+
+# 2) Show branch and commit visibility.
+$branch = git branch --show-current
+Write-Host ("Current branch: {0}" -f $branch) -ForegroundColor Yellow
+Write-Host 'Recent commits:' -ForegroundColor Cyan
+git log --oneline --decorate -n 12
+
+# 3) Show delta summary from base ref if available.
+git rev-parse --verify $BaseRef *> $null
+if ($LASTEXITCODE -eq 0) {
+  $range = "{0}...HEAD" -f $BaseRef
+  Write-Host ("Diff summary vs {0}:" -f $BaseRef) -ForegroundColor Cyan
+  git diff --stat "$range"
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host ("Could not compute diff summary for range: {0}" -f $range) -ForegroundColor Yellow
+  }
+} else {
+  Write-Host ("Base ref not found locally: {0}" -f $BaseRef) -ForegroundColor Yellow
+}
+
+Write-Host 'Manual readiness checks completed.' -ForegroundColor Green

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -16,9 +16,12 @@ $requiredToolkitFiles = @(
   'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs',
   'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs',
   'Assets/Editor/Toontown/Config/ObjectTypeMap.json',
+  'Assets/Editor/Toontown/ToontownQuickStartWindow.cs',
+  'Assets/Editor/Toontown/ToontownToolkitPaths.cs',
   'Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs',
-  'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs'
+  'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs',
+  'Assets/Editor/Toontown/Samples/toontown_sample_world.py'
 )
 
 foreach ($path in $requiredToolkitFiles) {

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -15,6 +15,7 @@ $requiredToolkitFiles = @(
   'Assets/Editor/Toolkit/WorldData/WorldDataFormatAdapterRegistry.cs',
   'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs',
   'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs',
+  'Assets/Editor/Toontown/Config/ObjectTypeMap.json',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs'
 )

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -13,6 +13,8 @@ $requiredToolkitFiles = @(
   'Assets/Editor/Toolkit/WorldData/WorldDataToolRouteResolver.cs',
   'Assets/Editor/Toolkit/WorldData/WorldDataToolLauncherRegistry.cs',
   'Assets/Editor/Toolkit/WorldData/WorldDataFormatAdapterRegistry.cs',
+  'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs',
+  'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs'
 )
@@ -24,4 +26,16 @@ foreach ($path in $requiredToolkitFiles) {
 }
 
 Write-Host 'Toolkit scaffolding files: OK' -ForegroundColor Green
+
+# Ensure Toontown reader/writer are not left as scaffold-only implementations.
+$stubMatches = git grep -n "scaffold and has not been implemented yet" -- `
+  "Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs" `
+  "Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs" 2>$null
+
+if ($LASTEXITCODE -eq 0 -and $stubMatches) {
+  Write-Host $stubMatches
+  throw "Toontown reader/writer still contains scaffold placeholders."
+}
+
+Write-Host 'Toontown reader/writer implementation guard: OK' -ForegroundColor Green
 Write-Host 'Primary checks passed.' -ForegroundColor Green

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -1,0 +1,27 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host '=== Primary Checks ===' -ForegroundColor Cyan
+
+# Run baseline project checks first.
+& "$PSScriptRoot/checks.ps1"
+
+# Ensure key toolkit routing/scaffolding files exist.
+$requiredToolkitFiles = @(
+  'Assets/Editor/Toolkit/WorldData/WorldDataRouterWindow.cs',
+  'Assets/Editor/Toolkit/WorldData/WorldDataToolRouteResolver.cs',
+  'Assets/Editor/Toolkit/WorldData/WorldDataToolLauncherRegistry.cs',
+  'Assets/Editor/Toolkit/WorldData/WorldDataFormatAdapterRegistry.cs',
+  'Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs',
+  'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs'
+)
+
+foreach ($path in $requiredToolkitFiles) {
+  if (-not (Test-Path $path)) {
+    throw "Missing required toolkit file: $path"
+  }
+}
+
+Write-Host 'Toolkit scaffolding files: OK' -ForegroundColor Green
+Write-Host 'Primary checks passed.' -ForegroundColor Green

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -16,6 +16,7 @@ $requiredToolkitFiles = @(
   'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs',
   'Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentWriter.cs',
   'Assets/Editor/Toontown/Config/ObjectTypeMap.json',
+  'Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs'
 )

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -60,4 +60,8 @@ if ($LASTEXITCODE -eq 0 -and $stubMatches) {
 }
 
 Write-Host 'Toontown reader/writer implementation guard: OK' -ForegroundColor Green
+
+# Validate bundled sample world for first-run quick-start flow.
+& "$PSScriptRoot/toontown-sample-sanity.ps1"
+
 Write-Host 'Primary checks passed.' -ForegroundColor Green

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -28,6 +28,23 @@ foreach ($path in $requiredToolkitFiles) {
 
 Write-Host 'Toolkit scaffolding files: OK' -ForegroundColor Green
 
+# Validate Toontown type-map config JSON shape.
+$typeMapPath = 'Assets/Editor/Toontown/Config/ObjectTypeMap.json'
+try {
+  $rawJson = Get-Content -Raw $typeMapPath
+  $jsonObj = $rawJson | ConvertFrom-Json
+  if (-not $jsonObj.defaultType) {
+    throw "Missing 'defaultType' in $typeMapPath"
+  }
+  if (-not $jsonObj.rules) {
+    throw "Missing 'rules' array in $typeMapPath"
+  }
+} catch {
+  throw "Invalid Toontown type-map config: $($_.Exception.Message)"
+}
+
+Write-Host 'Toontown type-map config: OK' -ForegroundColor Green
+
 # Ensure Toontown reader/writer are not left as scaffold-only implementations.
 $stubMatches = git grep -n "scaffold and has not been implemented yet" -- `
   "Assets/Editor/Toolkit/WorldData/Adapters/Toontown/ToontownWorldDataDocumentReader.cs" `

--- a/scripts/primary-checks.ps1
+++ b/scripts/primary-checks.ps1
@@ -18,6 +18,7 @@ $requiredToolkitFiles = @(
   'Assets/Editor/Toontown/Config/ObjectTypeMap.json',
   'Assets/Editor/Toontown/ToontownQuickStartWindow.cs',
   'Assets/Editor/Toontown/ToontownToolkitPaths.cs',
+  'Assets/Editor/Toontown/Validation/ToontownSampleSmokeTestRunner.cs',
   'Assets/Editor/Toontown/Validation/ToontownSampleValidationWindow.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataImporter.cs',
   'Assets/Editor/Toontown/World Data/ToontownWorldDataExporter.cs',

--- a/scripts/toontown-sample-sanity.ps1
+++ b/scripts/toontown-sample-sanity.ps1
@@ -1,0 +1,30 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host '=== Toontown Sample Sanity ===' -ForegroundColor Cyan
+
+$samplePath = 'Assets/Editor/Toontown/Samples/toontown_sample_world.py'
+if (-not (Test-Path $samplePath)) {
+  throw "Missing Toontown bundled sample: $samplePath"
+}
+
+$content = Get-Content -Raw $samplePath
+
+if ($content -notmatch "objectStruct\s*=\s*\{") {
+  throw "Bundled sample is missing objectStruct root assignment."
+}
+
+if ($content -notmatch "'Objects'\s*:\s*\{") {
+  throw "Bundled sample is missing 'Objects' dictionary."
+}
+
+if ($content -notmatch "sample-zone-root") {
+  throw "Bundled sample is missing expected root object id: sample-zone-root."
+}
+
+if ($content -notmatch "phase_4/models/props/mailbox") {
+  throw "Bundled sample is missing expected mailbox model mapping."
+}
+
+Write-Host 'Toontown sample sanity: OK' -ForegroundColor Green


### PR DESCRIPTION
## Summary
This PR establishes a migration-safe Toontown foundation while keeping existing POTCO behavior intact.

### Included
- Shared world-data routing and adapter contracts for game-flavor switching.
- Toontown reader/writer scaffolding with parser hardening and type-map inference.
- First-run Toontown usability path:
  - `Toontown/Quick Start`
  - bundled sample world
  - importer/exporter shortcuts
  - sample validator + CSV export
  - one-click smoke test
- Workflow/CI guardrails:
  - `Primary CI`
  - `Commit Quality`
  - `PR Readiness`
  - `Weekly Health`
  - `Sun Action`
  - `Toontown Smoke Gate`
- Contributor/process docs and release/readiness checklists.

## Validation
- `scripts/primary-checks.ps1`
- `scripts/commit-message-check.ps1 -BaseRef upstream/main`
- Unity Toontown smoke run: **PASS** (input/output object counts match)

## Reviewer Focus
1. Shared routing/adapter boundaries.
2. Toontown parser/writer behavior and warnings.
3. Quick-start + smoke flow usability.
4. CI workflow trigger scope and maintainability.
